### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-28
+
+### Added
+
+- Added the Semper book, with executable examples covering the language,
+  algebraic canonization, saturation, anti-unification, and policy repair.
+
+### Changed
+
+- Made malformed algebraic declarations and rule right-hand sides fail during
+  resolution instead of relying on unchecked representation invariants.
+- Clarified that anti-unification optimality is relative to the equalities
+  materialized in the selected e-graph completion mode.
+- Aligned every workspace package and internal published dependency at
+  version `0.3.0`.
+
+### Fixed
+
+- Honored `:assoc-left` and `:assoc-right` flattening directions during both
+  source-term construction and rewrite right-hand-side construction.
+- Rejected algebraic operators whose argument and result sorts make variadic
+  singleton collapse unsound, as well as conflicting associativity tags.
+- Added lexically scoped right-hand-side comprehension locals without mutating
+  query match shapes or runtime match rows.
+- Enforced collection element sorts, fixed right-hand-side arity, and
+  literal-producing comprehension filters.
+- Rebuilt before every `run :until` observation, including the final
+  observation after exhausting the rule-round budget.
+
 ## [0.2.0] - 2026-08-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "containers-conformance"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "containers-verus-canary"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "semi-persistent-containers",
  "semi-persistent-containers-verus",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "semi-persistent"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "semi-persistent-containers-verus",
  "semi-persistent-egraph",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "semi-persistent-abstract-domains"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rand 0.10.2",
  "vstd",
@@ -881,14 +881,14 @@ dependencies = [
 
 [[package]]
 name = "semi-persistent-au-verus"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "vstd",
 ]
 
 [[package]]
 name = "semi-persistent-containers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "hashbrown",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "semi-persistent-containers-verus"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "foldhash",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "semi-persistent-egraph"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "criterion",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "semi-persistent-traversals"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "semi-persistent-traversals-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "traversals-compile-tests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "semi-persistent-traversals",
 ]

--- a/abstract-domains/Cargo.toml
+++ b/abstract-domains/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent-abstract-domains"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/au-verus/Cargo.toml
+++ b/au-verus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent-au-verus"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/containers-conformance/Cargo.toml
+++ b/containers-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containers-conformance"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false
@@ -10,8 +10,8 @@ publish = false
 # This development-only crate is the only package that depends on both.
 
 [dependencies]
-semi-persistent-containers = { path = "../containers", version = "0.2.0" }
-semi-persistent-containers-verus = { path = "../containers-verus", version = "0.2.0" }
+semi-persistent-containers = { path = "../containers", version = "0.3.0" }
+semi-persistent-containers-verus = { path = "../containers-verus", version = "0.3.0" }
 # The Verus `define_id*!` macros expand `::vstd` paths, so a crate invoking them
 # needs `vstd` in scope even though ghost specifications erase at runtime.
 vstd = "=0.0.0-2026-08-02-0125"

--- a/containers-verus/Cargo.toml
+++ b/containers-verus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent-containers-verus"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "Apache-2.0"

--- a/containers-verus/canary/Cargo.toml
+++ b/containers-verus/canary/Cargo.toml
@@ -7,7 +7,7 @@
 # See src/lib.rs.
 [package]
 name = "containers-verus-canary"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 semi-persistent-containers-verus = { path = ".." }
 # Production containers, for side-by-side shape comparison in fixtures.
-semi-persistent-containers = { path = "../../containers", version = "0.2.0" }
+semi-persistent-containers = { path = "../../containers", version = "0.3.0" }
 vstd = "=0.0.0-2026-08-02-0125"
 
 [features]

--- a/containers/Cargo.toml
+++ b/containers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent-containers"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "Apache-2.0"

--- a/doc/book/examples/20-dogwood-simple.egg
+++ b/doc/book/examples/20-dogwood-simple.egg
@@ -64,7 +64,9 @@
 (function args (ArgSet) ArgSet :assoc-comm-idem :identity (noArgs))
 (function fnil () Path)
 (function fld (FSeg Path) Path)
-(function win (IBig) Win)
+(function secs (IBig) Win)
+(function mins (IBig) Win)
+(function secsTimes (IBig IBig) Win)
 
 (function request () Kind)
 (function response () Kind)
@@ -108,7 +110,7 @@
       (temporal
         (tGte
           (agg (count (bcons (tyTimepoint) (bnil))
-                 (formerly (win 900)
+                 (formerly (mins 15)
                    (tAnd
                      (pred (aHttpRequest) (request) healthArgs)
                      (tp (bvar 0))))))
@@ -122,7 +124,7 @@
         (tLte
           (tInt 1)
           (agg (count (bcons (tyTimepoint) (bnil))
-                 (formerly (win 900)
+                 (formerly (secs 900)
                    (tAnd
                      (tp (bvar 0))
                      (pred (aHttpRequest) (response) healthArgsFlipped)))))))
@@ -136,7 +138,7 @@
       (temporal
         (tGte
           (agg (count (bcons (tyTimepoint) (bnil))
-                 (formerly (win 900)
+                 (formerly (secs 900)
                    (tAnd
                      (pred (aHttpRequest) (request) healthArgs)
                      (tp (bvar 0))))))
@@ -150,7 +152,7 @@
       (temporal
         (tGte
           (agg (count (bcons (tyTimepoint) (bnil))
-                 (formerly (win 900)
+                 (formerly (secs 900)
                    (tAnd
                      (pred (aHttpRequest) (response) healthArgs)
                      (tp (bvar 0))))))
@@ -159,8 +161,11 @@
       pathIsDeploy)))
 
 ;; ANCHOR: dogwood-identity
+(rewrite (mins x) (secsTimes x 60))
+(rewrite (secsTimes x y) (secs (IBig::* x y)))
 (birewrite (tLte a b) (tGte b a))
 (run 4)
+(check (= (mins 15) (secs 900)))
 ;; ANCHOR_END: dogwood-identity
 
 (check (!= candA candB))

--- a/doc/book/src/17-what-autoformalization-is.md
+++ b/doc/book/src/17-what-autoformalization-is.md
@@ -1,4 +1,4 @@
-# What autoformalization is
+# Using e-graphs and anti-unification for semantic comparison in autoformalization
 
 Autoformalization turns a natural-language requirement into a formal artifact.
 This chapter defines the review problem, explains what ordinary checks leave

--- a/doc/book/src/20-dogwood-simple.md
+++ b/doc/book/src/20-dogwood-simple.md
@@ -92,7 +92,7 @@ The candidates also contain six presentational differences:
 | temporal conjunction order | `tAnd :assoc-comm-idem` |
 | predicate field order | `args :assoc-comm-idem` |
 | `method == "POST"` versus `"POST" == method` | `eEq :comm` |
-| `15m` versus `900s` | windows normalized to seconds during encoding |
+| `15m` versus `900s` | rewrite `mins` through `secsTimes`, then constant-fold its product |
 | `count >= 1` versus `1 <= count` | `(birewrite (tLte a b) (tGte b a))` |
 
 ## Encoding Dogwood in Semper
@@ -112,7 +112,8 @@ main correspondences are:
 | `permit (...) when ...` | `rule`, `permit`, and `head` |
 | Cedar conditions and multiple `when` clauses | `Expr` terms under `eAnd` |
 | `when temporal { phi }` | `(temporal phi)` |
-| `formerly within 15m phi` | `(formerly (win 900) phi)` |
+| `formerly within 15m phi` | `(formerly (mins 15) phi)` |
+| `formerly within 900s phi` | `(formerly (secs 900) phi)` |
 | `Action::"..."::response{...}` | `(pred action response args)` |
 | predicate field assignments | `arg` terms collected by `args` |
 | `count for (t: Timepoint)` | `count`, `bcons`, and `(bvar 0)` |
@@ -123,6 +124,18 @@ Here is the complete executable model:
 ```lisp
 {{#include ../examples/20-dogwood-simple.egg}}
 ```
+
+The encoding retains each candidate's original time unit. The rewrite from
+`mins` to `secs` states the conversion inside the comparison theory:
+
+```lisp
+{{#include ../examples/20-dogwood-simple.egg:dogwood-identity}}
+```
+
+The first rule builds `(secsTimes 15 60)`. The second rule binds both operands
+as `IBig` literal values and evaluates the eager `IBig::*` primitive, reducing
+the intermediate term to `(secs 900)`. The equality is therefore derived by
+visible rewrite rules rather than imposed while translating the policies.
 
 The identity of `eAnd` represents an omitted condition. It lets the
 anti-unifier align candidate A's path guard with `eTrue` instead of replacing
@@ -155,7 +168,7 @@ points:
             (count
               (bcons tyTimepoint bnil)
               (formerly
-                (win 900)
+                (mins 15)
                 (tAnd
                   (tp (bvar 0))
                   (pred

--- a/doc/book/src/B-command-reference.md
+++ b/doc/book/src/B-command-reference.md
@@ -1,5 +1,8 @@
 # Annex B. Command reference
 
+This annex is a compact index of Semper's commands. Follow the chapter links
+for semantics and [Annex A](A-full-grammar.md) for the complete grammar.
+
 ## Symbol declarations and algebraic properties
 
 | Command | Effect |
@@ -28,3 +31,83 @@ A bare operator application at top level is an insertion command. A name
 introduced by `let` denotes the resulting e-class and may be used wherever a
 ground term is accepted. [Chapter 3](03-sorts-and-terms.md#building-a-term)
 explains term construction in detail.
+
+## Rules
+
+| Command | Effect |
+| --- | --- |
+| `(rewrite lhs rhs tags...)` | Match `lhs`, build `rhs`, and merge it with the matched root class. |
+| `(birewrite lhs rhs tags...)` | Install one rewrite in each direction. Both sides use pattern syntax. |
+| `(rule (pattern...) (action...) tags...)` | Run a conjunctive query and execute its actions for every match. |
+
+| Modifier | Accepted by | Effect |
+| --- | --- | --- |
+| `:when (pattern...)` | `rewrite`, `birewrite` | Add conjuncts to the query. A primitive predicate here computes over bound literal values. |
+| `:subsume` | `rewrite` | After applying the rewrite, hide the matched e-node from future pattern indexes. |
+| `:ruleset r` | all three forms | Put the installed rule in declared ruleset `r` instead of the default ruleset. |
+
+Modifiers may appear in any order. `birewrite` rejects `:subsume`; a general
+`rule` puts guards in its query list and accepts only `:ruleset` as a trailing
+modifier.
+
+### General-rule actions
+
+| Action | Effect |
+| --- | --- |
+| `(union lhs rhs)` | Build both RHS terms and merge their classes. |
+| `(f rhs...)` | Build and insert an application. RHS splices and comprehensions are accepted in its variadic children. |
+| `(set (f rhs...) value)` | Reserved syntax. It parses, but execution is not implemented. |
+
+[Chapter 5](05-rules-and-patterns.md) defines pattern matching, multiplicities,
+rest variables, comprehensions, modifiers, and action ordering.
+
+## Running rules and scopes
+
+| Command | Effect |
+| --- | --- |
+| `(run n)` | Run the untagged default ruleset for at most `n` iterations. |
+| `(run r n)` | Run only declared ruleset `r` for at most `n` iterations. |
+| `(run n :until (= a b))` | Stop early when `a` and `b` join. A named run may use the same goal. |
+| `(run n :until (!= a b))` | Stop early when the two terms are in different classes. This does not assert a persistent disequality. |
+| `(push)` | Record a semi-persistent scope. |
+| `(push :shrink)` | Reclaim sufficiently overallocated storage, then record a scope. |
+| `(pop)` | Restore the most recent scope, including e-graph, installed-rule, and runtime-name state. |
+
+A run selects exactly one ruleset. [Chapter 8](08-equality-saturation.md)
+defines round ordering, stopping, and statistics. [Chapter 7](07-semi-persistence.md)
+defines scope lifetime and `:shrink`.
+
+## Checks, extraction, and statistics
+
+| Command | Effect |
+| --- | --- |
+| `(check term)` | Build `term`. This form has no additional truth or equality test. |
+| `(check (= a b))` | Rebuild and require `a` and `b` to belong to the same e-class. |
+| `(check (!= a b))` | Rebuild and require the terms to belong to different e-classes under the selected completion mode. |
+| `(extract term)` | Rebuild and print a lowest-cost extractable representative. |
+| `(print-size)` | Print nonzero per-operator e-node counts and the total. |
+| `(print-size f)` | Print the e-node count for operator `f`. |
+| `(print-stats)` | Print current graph counts and the most recent run's counters. |
+| `(print-stats :file "path.json")` | Write the same statistics as JSON. |
+
+[Chapter 8](08-equality-saturation.md) defines extraction and statistics.
+[Chapter 11](11-three-congruence-closures.md) explains how the completion mode
+affects equality and disequality checks.
+
+## Anti-unification
+
+| Command | Effect |
+| --- | --- |
+| `(antiunify left right options...)` | Compute and print an anti-unifier. |
+| `(checkau left right options...)` | Compute the same result and fail if its size exceeds `:max_size`; print nothing on success. |
+
+| Option | Values | Default | Effect |
+| --- | --- | --- | --- |
+| `:algorithm` | `uct`, `exact` | `uct` | Select budgeted graph search or exhaustive exact search. |
+| `:playouts` | unsigned integer | `1000` | Set the UCT playout budget. Exact search does not use it. |
+| `:cycles` | `sides`, `sides-current`, `pair` | `sides` | Select the cycle-context policy defined in Chapter 14. |
+| `:max_size` | unsigned 32-bit integer | `u32::MAX` (`4294967295`) | Set the inclusive upper bound checked by `checkau`; unavailable on `antiunify`. |
+
+[Chapter 12](12-what-anti-unification-is.md) defines the result and size bound.
+[Chapters 14](14-exact-algorithm.md) and [15](15-graph-search.md) define the
+algorithms, cycle modes, and playout budget.

--- a/doc/book/src/C-flag-reference.md
+++ b/doc/book/src/C-flag-reference.md
@@ -1,1 +1,72 @@
 # Annex C. Flag reference
+
+The command-line form is:
+
+```text
+semi-persistent [OPTIONS] <FILE>
+```
+
+`FILE` is the required path to one Semper program.
+
+## Representation and literal model
+
+| Flag | Values | Default | Effect |
+| --- | --- | --- | --- |
+| `--id-bits` | `31`, `63` | `31` | Select 31-bit or 63-bit e-class identifiers. |
+| `--push-pop` | `diff`, `clone` | `diff` | Select scope storage. `diff` uses semi-persistent logs; `clone` is accepted as a value but currently exits with “not yet implemented.” |
+| `--types` | `machine`, `bignum` | `bignum` | Select comma-separated literal groups. `machine,bignum` enables both groups. |
+| `--proofs` | flag | off | Record merge justifications for proof extraction. |
+| `--dump-proofs FILE` | path | none | Write one proof-path record per e-node after execution. Requires `--proofs`. |
+
+The machine group provides `i64`, `u64`, `f64`, `usize`, `String`, and `bool`;
+the bignum group provides `IBig`, `UBig`, `RBig`, `String`, and `bool`.
+
+## Saturation and completion
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `--use-naive` | selected | Explicitly select full re-matching each round. Conflicts with `--use-semi-naive`. |
+| `--use-semi-naive` | off | Select delta-driven saturation. |
+| `--derive-ac-eqs` | off | Run eager AC completion during rebuild. Conflicts with `--lazy-ac-eqs`. |
+| `--lazy-ac-eqs` | off | Run goal-directed AC completion for equality and disequality checks. |
+| `--check-ac-basis` | off | Print expensive reduced-basis invariant checks during eager completion. It has no effect without `--derive-ac-eqs`. |
+| `--count-match-steps` | off | Count and report matching work. |
+
+[Chapters 9](09-naive-and-semi-naive.md) and
+[11](11-three-congruence-closures.md) define the evaluation and completion
+modes.
+
+## Matching and union policies
+
+| Flag | Value | Default | Effect |
+| --- | --- | --- | --- |
+| `--runtime-scheduling` | flag | off | Choose atom order per binding from live bucket lengths. Conflicts with `--auto-scheduling`. |
+| `--auto-scheduling` | flag | off | Select static or per-binding atom ordering for each rule and round. |
+| `--sampled-selectivity` | flag | off | Estimate bound-key fan-out by sampling the emitter relation. |
+| `--sampler-k` | nonnegative integer | `32` | Set emitter nodes drawn per sampled estimate. Relevant with `--sampled-selectivity`. |
+| `--sampler-bootstrap` | nonnegative integer | `0` | Set bootstrap resamples per estimate; zero disables the guard. |
+| `--sampler-cv` | floating-point number | `1.0` | Reject a bootstrapped estimate when its coefficient of variation exceeds this threshold. |
+| `--union-by` | `rank`, `size`, `uses`, `sum` | `rank` | Choose the surviving representative by union-find rank, class size, use-list length, or size plus uses. |
+
+These policies change operational work and representative choice, not the
+equalities asserted by the input program.
+
+## Help
+
+| Flag | Effect |
+| --- | --- |
+| `-h`, `--help` | Print the generated command-line help. |
+
+## Feature-gated diagnostics
+
+Two environment variables affect binaries built with optional instrumentation
+features; they are not command-line flags:
+
+| Build feature and environment | Effect |
+| --- | --- |
+| `phase-timing`, `EGRAPH_PHASE=1` | Print aggregate rebuild, indexing, matching, and application timings at exit. |
+| `phase-timing`, `EGRAPH_PHASE=rounds` | Also print one timing line per saturation round. |
+| `seek-stats`, `EGRAPH_SEEK=1` | Print leapfrog seek-distance histograms at exit. |
+
+Without the corresponding Cargo feature, setting the environment variable has
+no effect.

--- a/doc/book/src/SUMMARY.md
+++ b/doc/book/src/SUMMARY.md
@@ -29,7 +29,7 @@
 
 # Part IV. Autoformalization
 
-- [What autoformalization is](17-what-autoformalization-is.md)
+- [Using e-graphs and anti-unification for semantic comparison in autoformalization](17-what-autoformalization-is.md)
 - [Clustering samples by equality saturation](18-clustering-samples.md)
 - [Explaining the differences between clusters](19-explaining-differences.md)
 - [Repair by disagreement](20-dogwood-simple.md)

--- a/egraph/Cargo.toml
+++ b/egraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent-egraph"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "Apache-2.0"
@@ -31,7 +31,7 @@ phase-timing = []
 seek-stats = []
 
 [dependencies]
-semi-persistent-containers = { package = "semi-persistent-containers-verus", path = "../containers-verus", version = "0.2.0" }
+semi-persistent-containers = { package = "semi-persistent-containers-verus", path = "../containers-verus", version = "0.3.0" }
 vstd = "=0.0.0-2026-08-02-0125"
 clap = { version = "4.6.0", features = ["derive"] }
 num-bigint.workspace = true

--- a/semi-persistent/Cargo.toml
+++ b/semi-persistent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "Apache-2.0"
@@ -11,6 +11,6 @@ documentation = "https://docs.rs/semi-persistent"
 readme = "../README.md"
 
 [dependencies]
-semi-persistent-containers = { package = "semi-persistent-containers-verus", path = "../containers-verus", version = "0.2.0" }
-semi-persistent-egraph = { path = "../egraph", version = "0.2.0" }
-semi-persistent-traversals = { path = "../traversals", version = "0.2.0" }
+semi-persistent-containers = { package = "semi-persistent-containers-verus", path = "../containers-verus", version = "0.3.0" }
+semi-persistent-egraph = { path = "../egraph", version = "0.3.0" }
+semi-persistent-traversals = { path = "../traversals", version = "0.3.0" }

--- a/traversals/Cargo.toml
+++ b/traversals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent-traversals"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ homepage = "https://github.com/yaspar-org/semi-persistent"
 documentation = "https://docs.rs/semi-persistent-traversals"
 
 [dependencies]
-semi-persistent-traversals-derive = { path = "derive", version = "0.2.0" }
+semi-persistent-traversals-derive = { path = "derive", version = "0.3.0" }
 rustc-hash = "2"
 smallvec = "1"
 

--- a/traversals/compile-tests/Cargo.toml
+++ b/traversals/compile-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traversals-compile-tests"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/traversals/derive/Cargo.toml
+++ b/traversals/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semi-persistent-traversals-derive"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- align all workspace packages and published path dependencies at 0.3.0
- document the algebraic-canonization, RHS-comprehension, and `run :until` soundness fixes
- encode the Dogwood minute/second equivalence as executable rewrites with primitive constant folding
- complete the book command and CLI flag references and retitle the autoformalization chapter
- prepare the trusted-publishing workflow for the `v0.3.0` tag

## Local validation

- `cargo fmt --all -- --check`
- `bash scripts/check-oss-scaffold.sh`
- `cargo metadata --locked --no-deps --format-version 1` (all packages at 0.3.0)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `bash doc/book/build.sh`
- `cargo test --locked -p semi-persistent-egraph --test egg_tests book_examples`
- direct execution of `doc/book/examples/20-dogwood-simple.egg`
- crates.io dry-run packaging for the three dependency-leaf crates
- `git diff --check`

The dependent crates are intentionally published by the tag workflow only after their new 0.3.0 dependencies become visible in the crates.io index.