### PR TITLE
Fix canonization confluence defects and turn arithmetic panics into reported errors

### DIFF
--- a/doc/book/src/05-rules-and-patterns.md
+++ b/doc/book/src/05-rules-and-patterns.md
@@ -287,8 +287,10 @@ use `u64::+`, `u64::-`, `u64::*`, `u64::/`, `u64::%`, `u64::min`, and
 Subtraction is accepted only when the collected left-hand-side interval proves
 that it cannot underflow. Division and remainder require a divisor whose
 interval excludes zero. Addition and multiplication use checked arithmetic at
-runtime. An output multiplicity of zero omits the child without evaluating its
-term.
+runtime: an overflow, or a computed count too wide for the configured
+multiplicity type, stops the run with an error naming the rule and the operands
+rather than wrapping or aborting the process. An output multiplicity of zero
+omits the child without evaluating its term.
 
 ## Splicing and comprehensions
 

--- a/doc/book/src/11-three-congruence-closures.md
+++ b/doc/book/src/11-three-congruence-closures.md
@@ -57,6 +57,29 @@ over associative, AC, or ACI nodes. Use lazy mode for a limited sequence of
 equality questions. Use eager mode when rules, extraction, anti-unification,
 or another graph reader must observe completion-derived classes.
 
+One practical point when choosing plain mode: because plain mode derives no
+AC consequences, its answer to an equality query over AC or ACI nodes can
+depend on the **order the statements appear in**. Flattening a nested
+same-operator argument is declined once that argument's class is referenced
+as a child anywhere else, and that condition never becomes false again, so
+building an unrelated term earlier can change how a later term is spelled:
+
+```lisp
+(let t0 (Add (Mul D D) A))    ; delete this line, or move it below, and
+(let t1 (Mul D D A D))        ; the following check passes instead of failing
+(let t2 (Mul A D (Mul D D)))
+(check (= t1 t2))
+```
+
+Both readings are sound — a reordering never makes a *false* equality
+provable, only a true one unprovable — and within a single term the order is
+fixed, so the effect appears only across statements. If a program depends on
+equalities like this one, that is the signal to enable `--derive-ac-eqs` or
+`--lazy-ac-eqs`, which prove it in either order. Operators declared
+associative-only (`:assoc`) are not affected: their flattening is decided
+from the written form of the application, so it does not depend on what else
+the program has built.
+
 Chapter 23 collects the limits and qualifications of these modes. The
 procedures are specified in
 [`ac-completion-spec.md`](https://github.com/yaspar-org/semi-persistent/blob/main/egraph/doc/design/ac-completion-spec.md),

--- a/egraph/benches/saturate_bench.rs
+++ b/egraph/benches/saturate_bench.rs
@@ -197,10 +197,13 @@ enum Driver {
 #[inline]
 fn run(driver: Driver, eg: &mut EG, rules: &[Rule], limit: usize) -> usize {
     let g = GlobalCtx::<SortId, ENodeId>::new();
+    // The workloads' rules are total on their operands, so a fault is a broken
+    // workload rather than a measurement.
     let r = match driver {
         Driver::Naive => saturate(rules, eg, &NiraModel, limit, &g),
         Driver::Semi => saturate_semi(rules, eg, &NiraModel, limit, &g),
-    };
+    }
+    .expect("benchmark rules are total");
     // Fold both the result and the final graph size into the returned value:
     // a change that silently stops saturating would otherwise look like a win.
     r.iterations + eg.node_count() + usize::from(r.saturated)

--- a/egraph/doc/design/04-canonization.md
+++ b/egraph/doc/design/04-canonization.md
@@ -86,6 +86,35 @@ nodes. A node visit does not deliberately create a fresh scratch vector, but a
 buffer may allocate when a larger input exceeds its retained capacity. The
 caller reads the buffer length after canonization to determine the new span.
 
+### Inverse-pair cancellation, on both paths
+
+An op declaring `:inverse g` also cancels summand pairs related by `g`
+(`x ∘ inv(x) = e`, `group_cancel_pairs`), which can empty a monomial and hand the
+degeneracy resolution the unit. Like the unit drop, this is a canonization law and not a
+completion inference, so it holds in plain mode.
+
+Unlike the other laws in this list, its condition **opens** rather than closes: it needs the
+node `inv(x)` to exist *and* to resolve into a summand class, and a later merge can make that
+true for a node that was already canonical. Applying it only at build was therefore not
+enough, and left plain mode inconsistent with itself — `(+ a (neg b))` followed by
+`(union a b)` did not reduce to `0`, while the same two statements in the other order did:
+
+```lisp
+(let s (Add (A) (Neg (B))))
+(union (A) (B))
+(check (= s (Zero)))          ;; used to fail; the control order always passed
+```
+
+The law is therefore re-applied after merges, by `canon_repair_round` in `rebuild`. That pass
+cannot be a recanonization step: `recanonize_node` writes children back into the node's
+existing span and the result may need a *different* node (or the unit class), which is an
+equality rather than a representation change. So it materializes the cancelled monomial with
+`add` and merges, labelled `Justification::InverseCancel`, in the same style as `cc_round`.
+
+Cancellation is purely subtractive, so unlike the flattening laws it can never grow a
+monomial: each repair merge strictly reduces the class count and the fixpoint needs no growth
+budget. Covered by `inverse_cancel_after_merge.egg` and its control.
+
 ## `SetCanon` — Set Canonization
 
 For ACI operators: children are deduplicated ids, stored in sorted order.

--- a/egraph/doc/design/04-canonization.md
+++ b/egraph/doc/design/04-canonization.md
@@ -211,6 +211,31 @@ completion is enabled. Plain mode does not run that pass, and even completion
 mode does not claim a complete decision procedure for arbitrary ground
 associative equations.
 
+Note what that gap does *not* cover, because the two cases were confused once
+and the distinction is the whole point. Flattening a nested application the
+program **wrote** — `op(op(a,b),c)` — is not in the gap: it is associativity on
+the term, it depends on no union, and it is decided from the syntax tree before
+any child id exists, at both places a term is written: `push_seq_args`
+(`interpret.rs`) for a ground term, and `eval_seq_args` (`apply.rs`) for a rule
+right-hand side. That placement is deliberate and is the only correct one
+available.
+`pure_seq_node` cannot decide it, because purity *closes*: a union into the
+child's class turns the test false forever, so `(union (F a b) blob)` written
+before `(F (F a b) c)` used to store the nested spelling while the reverse
+order stored the flat one — the same program with two answers
+(`seq_flatten_order_independent.egg`). Nor can `EGraph::add` decide it: by then
+a child is a plain node id, and a nested application is indistinguishable from
+a class id that merely happens to be a `Seq` node. RHS rest bindings supply
+exactly such ids, and splicing those rewrites uphill — `seq(a,b)` becomes
+`seq(unit,a,b)` and grows again every round under a rule that reintroduces the
+unit (`a_singleton_collapse.egg`).
+
+The gap above is the genuinely different case: the program wrote `op(x,d)` with
+`x` opaque, and only a *proved equation* `x = op(a,b)` relates it to
+`op(a,b,d)`. That is a consequence of the associative theory rather than a
+canonical form of what was written, so declining it in plain mode is correct
+rather than a defect.
+
 ### What flattening erases
 
 `ac-congruence-completeness.md` §2 states the trade for AC: flattening erases

--- a/egraph/doc/design/11-sortcheck-and-resolution.md
+++ b/egraph/doc/design/11-sortcheck-and-resolution.md
@@ -123,6 +123,32 @@ values it reads. Three things are checked here:
 
 `deps` is filled once every atom is resolved, by `link_pred_deps`.
 
+### Whole-Query Checks
+
+Two properties are not properties of a single atom, so they are checked once the
+atom list is complete. Both reject queries the matcher cannot execute; both would
+otherwise surface as a panic in `ematch` or, worse, as a silently dropped
+constraint.
+
+`check_rest_vars_linear` — **a rest variable has at most one writer.** `pre` and
+`suf` of one variadic atom count as two, so `(S ..r x ..r)` is rejected along
+with a rest shared between two atoms. Unlike a node variable, a repeated rest
+name cannot lower to a check: `ExpandA`, `DecomposeAC` and `DecomposeACI` write
+their spans unconditionally, and the `Step` enum has no span comparison, so the
+second writer would overwrite the first and the constraint would vanish — which
+admits matches the pattern excludes. Expressing the constraint instead of
+rejecting it needs a new `Step`.
+
+`check_nodes_bindable` — **every node variable of the `MatchShape` is bindable.**
+`MatchPool::push` unwraps every node slot, so a plan that leaves one unbound
+aborts when the first match is materialized. Every atom kind but `Eq` and `Pred`
+binds its own node variable and its local children, so bindability is the closure
+of those seeds under `Eq`, which copies a binding in whichever direction is
+already bound. An `Eq` with neither side in the closure is lowered by neither
+scheduler phase — `try_eager_lower` returns `None` and phase B's argmin skips
+`Eq` — and is silently dropped; this is the local counterpart of the case
+`Step::BindGlobal` handles for a global.
+
 ### Global Name Resolution
 
 When a child or variadic element name exists in `GlobalCtx`, the resolver emits

--- a/egraph/doc/design/A0-overview.md
+++ b/egraph/doc/design/A0-overview.md
@@ -138,6 +138,25 @@ survivor policy on the verified per-class counters. See
 the modes and [Future Work](A3-future-work.md) for the verification
 plan.
 
+**Caveat (statement order in plain mode):** one visible consequence of
+plain mode's incompleteness is that AC flattening depends on the order
+in which statements appear, so plain mode can answer the same equality
+query differently for two programs that differ only by a reordering.
+Flattening splices a nested same-op child only when the child's class is
+not yet referenced as a child elsewhere, and that condition is
+monotone-true, so building an unrelated term first can change how a
+later term is spelled. Within a single term the order is fixed by
+argument evaluation, so the effect is only across statements. Nothing
+unsound follows — a reordering never produces a *false* equality, only a
+missing one — but a program that needs AC consequences should enable
+`--derive-ac-eqs` or `--lazy-ac-eqs` rather than rely on plain mode.
+`ac-congruence-completeness.md` §6c records why every way of removing
+the dependence at build time is worse, and
+`egraph/tests/egg/ac_flatten_order_dependence*.egg` pins the behaviour
+in both orders and under completion. Associativity-only (`:assoc`)
+operators are *not* affected: their flattening is decided on the written
+syntax of the application, so it is order-independent.
+
 ### Relational pattern matching via leapfrog triejoin
 
 Patterns compile to flat relational atoms. Their relational intersections use

--- a/egraph/doc/design/A0-overview.md
+++ b/egraph/doc/design/A0-overview.md
@@ -87,8 +87,9 @@ find performance.
 ### Sound and extensible builtin operations
 
 Primitive operations on machine-word types (i64, u64, f64) are checked
-by default: overflow, division by zero, and lossy conversions panic
-rather than silently producing wrong results. Wrapping and saturating
+by default: overflow, division by zero, and lossy conversions stop the run
+with an error naming the rule and the operands, rather than silently
+producing wrong results. Wrapping and saturating
 variants (`wrapping_add`, `saturating_mul`, etc.) require explicit
 opt-in, so constant-folding rules are sound to execute by default and
 the engine never derives false equalities from silent wraparound.

--- a/egraph/doc/design/A1-language-guide.md
+++ b/egraph/doc/design/A1-language-guide.md
@@ -296,14 +296,30 @@ dispatch happens at resolve time based on the operator's `OpKind`.
 
 ### Non-Linear Variables
 
-A variable that appears more than once in a pattern is non-linear.
-The first occurrence binds; subsequent occurrences check equality
-(same e-class). This works uniformly across all operator kinds:
+An *element* variable that appears more than once in a pattern is
+non-linear. The first occurrence binds; subsequent occurrences check
+equality (same e-class). This works uniformly across all operator
+kinds:
 
 ```
 (rewrite (Add x x) (Dbl x)) ;; matches Add nodes where both children
                             ;; are in the same e-class
 ```
+
+A *rest* variable (`..r`) is the exception: it must be linear, and
+repeating one is a resolve error. The matcher has no step that compares
+two rest spans, so a repeated rest name cannot be checked — each
+occurrence would write the span and the last writer would win, dropping
+the constraint. This applies both across atoms and within one, so
+
+```
+(rule ((S ..r x) (S y ..r)) ((union x y)))  ;; error: '..r' written twice
+(rule ((S ..r x ..r))       ((union x x)))  ;; error: '..r' written twice
+```
+
+are both rejected. Use distinct names (`..p`, `..q`) when the two rests
+need not be equal; a constraint that two rests *are* equal cannot be
+expressed today.
 
 ### ACI Patterns (set semantics)
 

--- a/egraph/doc/design/A2-developer-guide.md
+++ b/egraph/doc/design/A2-developer-guide.md
@@ -132,17 +132,26 @@ the model inconsistent with the semantics its author intended even though it
 satisfies the Rust type signature.
 
 The provided integer machine operations use checked arithmetic for the
-unqualified names and panic on overflow or invalid integer division. This is
-not a blanket failure policy: `f64` operations use Rust/IEEE floating-point
-semantics, and string indexing operations return an empty string for invalid
-UTF-8 byte ranges.
+unqualified names. Overflow and invalid integer division are *partial*: `eval`
+returns `None`, which the engine reports as an `EvalError` naming the rule, the
+operation, and the operands, and the program exits nonzero. It stops the run
+rather than panicking, so a caller can tell a bad `.egg` program from a bug in
+the engine, and it is not a blanket failure policy: `f64` operations use
+Rust/IEEE floating-point semantics, and string indexing operations return an
+empty string for invalid UTF-8 byte ranges.
 
 Wrapping and saturating variants use Rust's standard method names
 (`wrapping_add`, `saturating_mul`, etc.) and require explicit opt-in.
 Arbitrary-precision types (IBig, UBig, RBig) do not overflow their numeric
-range, although partial operations such as division by zero can still panic.
-Operations that would produce unrepresentable exact results (for example,
-rational square root) are not provided.
+range, but they are still partial: division and remainder by zero, and a `UBig`
+subtraction whose result would be negative, report the same way. Operations that
+would produce unrepresentable exact results (for example, rational square root)
+are not provided.
+
+A fault ends the run at the action that hit it, and the effects of the actions
+already applied stay in the e-graph. Nothing reads the graph afterwards except a
+diagnostic, and undoing them would cost a rollback point per action on the hot
+path for a case that ends the program either way.
 
 When implementing a new `eval` function, specify its intended semantics and
 make it deterministic and total over the values on which the engine will call
@@ -153,7 +162,7 @@ relative to that external contract; no proof checks an arbitrary callback.
 
 | Model | Sorts | Use case |
 |-------|-------|----------|
-| `BignumModel` | bool, IBig, UBig, RBig | Arbitrary-precision operations relative to their documented callback semantics; no overflow, but partial operations can panic |
+| `BignumModel` | bool, IBig, UBig, RBig | Arbitrary-precision operations relative to their documented callback semantics; no overflow, and partial operations report an `EvalError` |
 | `MachineModel` | bool, i64, u64, f64, usize, String | Integer arithmetic checked by default; `f64` follows Rust/IEEE semantics; strings use Rust `String` |
 | `AllModel` | All of the above | Testing |
 

--- a/egraph/doc/design/ac-congruence-completeness.md
+++ b/egraph/doc/design/ac-congruence-completeness.md
@@ -367,21 +367,31 @@ shape and so to fire as expected.
 Case (b): a scalar variable that must bind to a compound sub-sum is not matched, and
 this can miss a real equality. It arises only when one variable must bind to a
 compound sub-sum as a single value, usually because the variable is reused, so its
-identity matters. One example is cancellation, `(+ ?x (neg ?x)) ⇒ 0`. Insert
-`a + b + (neg (a+b))`. To build `neg(a+b)` at all, the node `+(a,b)` must exist;
-call its class `c`. So `a+b` is in fact materialized as `c`, not virtual. But the
-outer sum flattens by substituting the child class of each summand, and the two
-leaves `a`, `b` are summands in their own right, so the outer node is:
+identity matters. The example to reach for is cancellation, `(+ ?x (neg ?x)) ⇒ 0` —
+but it is important to be precise about when it actually fails, because the obvious
+reading of it is wrong.
+
+Insert `c + (neg c)` where `c` is the class of `+(a,b)`. To build `neg(c)` at all,
+the node `+(a,b)` must exist, and *referencing it as `neg`'s child is what makes its
+class `atomic`* (§9a). §6c's `summand_form` therefore keeps it as one summand, so the
+outer node is:
 
 ```
-+{ a, b, neg(c) }     (not +{ c, neg(c) })
++{ c, neg(c) }
 ```
 
-Now match `(+ ?x (neg ?x))`: `neg(c)` is a summand, so `(neg ?x)` forces `?x = c`.
-The match then needs `c` to also be a summand, but the outer multiset is
-`{a, b, neg(c)}`, which contains `a` and `b` separately, not `c`. The match fails,
-and the rule that should reduce the term to `0` never fires. A genuine AC
-consequence is lost.
+and `(+ ?x (neg ?x))` matches with `?x = c`. **This case works**, in plain mode, with
+no completion: see `inverse_cancel_keeps_atomic_pair.egg`. An earlier revision of this
+chapter claimed the outer node was `+{a, b, neg(c)}` and the rule never fired. That
+described a flattening rule with no `atomic` condition, which the implementation does
+not have and must not have — see §6c, and the "why not just splice" note there.
+
+What case (b) does lose is a sub-sum that no node references as a non-same-op child,
+so nothing makes its class `atomic`, and it is spliced away before the reused variable
+can bind it. Build `h(+(a,b))` for some unrelated `h` and the class is atomic again,
+which is why the failure is fragile and why it is stated as a matching limit rather
+than a soundness problem: what is lost is a genuine AC consequence, never a false
+equality.
 
 It failed not because `a+b` is missing (it is present, as `c`), but because `c` was
 never substituted into the outer node to expose it. That is the inter-reduction of
@@ -827,8 +837,15 @@ the active set generally plateaus near the input size.
 
 ### Flattening (`WF_flat`) and the matcher-crash gate
 
-The engine requires **AC terms to be flattened** (`WF_flat`): an `f`-node never has an
-`f`-class child. This is a canonicalization invariant, not a completion-specific one: the
+The engine requires **AC terms to be flattened** (`WF_flat`): an `f`-node never has a
+**non-`atomic`** `f`-class child. The qualifier is not a detail and was missing from an
+earlier revision of this chapter. Stated without it — "never has an `f`-class child" — the
+invariant is simply **false** of the implementation, and it has to be: §5b's cancellation
+needs `+{c, neg(c)}` to keep `c` as one summand precisely when `c`'s class holds an
+`f`-node. §6c case 1 is the rule, and this is the invariant that follows from it.
+
+Nothing asserts on `WF_flat`; it is a documentation-level statement of what the build path
+establishes. This is a canonicalization invariant, not a completion-specific one: the
 materialization invariant of §1 needs every summand to be a real summand, and a nested
 `+f(+f(…),…)` hides one. §6c states exactly what to flatten (the class summand-form), gives
 the implementation argument that recanonicalization-time flattening is vacuous, and
@@ -892,6 +909,22 @@ Why this is the *right* predicate, and what it does to the worked examples:
   sums; it has no standalone atom form, so it must be spliced. This is the same `atomic`
   distinction that orients completion's rule RHS; flattening and completion agree by
   construction.
+
+  **Do not decompose that disjunction.** It reads like one algebraic condition ("holds a
+  non-AC node") plus one bookkeeping artifact ("referenced as a child"), and it is tempting
+  to conclude that only the first carries meaning. Both carry meaning, for *different*
+  reasons, and dropping either one breaks something distinct:
+
+  - "holds a non-AC node" is what keeps the splice from rewriting **uphill**. When a class
+    holds a genuine atom — `(union (+ c0 c1) c2)` — `c2` is the small spelling and `+(c0,c1)`
+    the large one. Splicing grows every AC node over that class, every round, without bound.
+    This is a *termination* property, not a spelling preference.
+  - "referenced as a child" is what preserves **§5b**. It is the only thing making
+    `[+(a,b)]` atomic in `+{c, neg(c)}`, and without it the cancellation pair is destroyed.
+
+  A predicate keeping only the first disjunct (class purity) still breaks §5b; one keeping
+  only the second still runs away. Both were implemented and measured before this note was
+  written.
 
 - **§5b is preserved.** In §5b, `c = +{a,b}` is a child of `neg(c)`, so its class is
   `atomic`. Canonicalizing `+{c, neg(c)}` therefore expands `c` to `summand_form(c) = {c}`
@@ -970,6 +1003,54 @@ The intuition: the act of *using* a class as an AC child is exactly what makes i
 permanently, so by the time a class is stored in a multiset it can never again be a splice
 candidate. Inlining is fundamentally a build-time operation, on a child that is non-atomic
 *at the moment its parent is built*; building the parent then makes it atomic forever after.
+
+**What the lemma does not establish.** Both statements above are about *re-running* the
+predicate on an already-stored child, and they are correct: a stored child is atomic, so a
+recanon-time flatten would splice nothing. Neither statement says the build-time choice is
+**canonical**, and it is not. The question they do not ask is the converse one:
+
+> can a class stop being a splice candidate *before* its parent is built?
+
+It can, and that is the whole content of the phrase "non-atomic *at the moment its parent is
+built*" above. `atomic` is monotone-true, so it answers "is this class referenced as a
+non-same-op child" with **so far**. Two programs that differ only in the order of two
+unrelated `let`s therefore store different spellings and land in different classes:
+
+```lisp
+(let t0 (Add (Mul D D) A))   ; referencing [Mul(D,D)] as an Add child makes it atomic
+(let t1 (Mul D D A D))
+(let t2 (Mul A D (Mul D D))) ; [Mul(D,D)] now atomic  ⇒  kept nested  ⇒  t1 ≠ t2
+```
+
+Move the `t0` line after `t2` and the same program proves `t1 = t2`. Both orders are in
+`ac_flatten_order_dependence.egg` / `..._reordered.egg`, and `..._eager.egg` shows
+`--derive-ac-eqs` proving it either way.
+
+This is **left as-is deliberately**, and the reason is worth recording because every
+alternative was tried and is worse:
+
+| alternative | why it fails |
+| --- | --- |
+| splice unconditionally (drop `atomic`) | destroys §5b's summand pair, and rewrites uphill without bound — measured as a runaway in the completion normalizer on the `ac_completion` bench workload |
+| require class *purity* instead of `atomic` | still breaks §5b, since `[+(a,b)]` is pure; and purity closes too, so the order dependence remains |
+| never splice | regresses `ac_flatten_build.egg`; nested and flat spellings stop being one class at all |
+| decide on the written syntax, not the class | breaks §5b for a §5b term written inline, e.g. `(Add (Add A B) (Neg (Add A B)))` |
+| supply the missing equality as a repair pass after merges | sound and it works, but it derives AC consequences in plain mode, which the mode is defined not to do; measured at **+73% nodes** on `rhs_mult_expr.egg` under `--derive-ac-eqs` |
+
+Note also that `atomic` **is** order-independent *within* a single term, because argument
+evaluation order is fixed. The dependence is only *across statements*, which is exactly the
+AC incompleteness the eager and lazy modes (§13) exist to close. Getting all AC consequences
+requires one of those modes; plain mode gives canonization plus congruence and no more.
+
+The A-only (`Seq`) analogue of this is a different matter and *is* fixed, because A-only
+operators admit neither `:identity` nor `:inverse` (the property resolver rejects both
+without `:comm`), so no §5b pair depends on a nested spelling being kept. There, the
+flattening decision is made in the term builder (`push_seq_args` in `interpret.rs`), on the
+*syntax* of the application, before child ids exist. It cannot be made in `EGraph::add`: by
+then a child is a plain id, and a nested application is indistinguishable from a class id
+that merely happens to be a `Seq` node — RHS rest bindings hand `add` exactly such ids, and
+splicing those rewrites `seq(a,b)` up to `seq(unit,a,b)` and again every round
+(`a_singleton_collapse.egg`). See `seq_flatten_order_independent.egg`.
 
 A worked trace (watch `atomic([S])`):
 

--- a/egraph/examples/acsite.rs
+++ b/egraph/examples/acsite.rs
@@ -102,11 +102,14 @@ fn main() {
     for _ in 0..reps {
         let (mut eg, rules) = ac_rules(width);
         let t = std::time::Instant::now();
+        // The benchmark's rules are total on their operands; a fault would mean
+        // the site itself is malformed, which is not what it measures.
         let r = if semi {
             saturate_semi(&rules, &mut eg, &NiraModel, 4, &g)
         } else {
             saturate(&rules, &mut eg, &NiraModel, 4, &g)
-        };
+        }
+        .expect("benchmark rules are total");
         let dt = t.elapsed().as_secs_f64() * 1e3;
         acc += r.iterations + eg.node_count();
         best = best.min(dt);

--- a/egraph/examples/allocprobe.rs
+++ b/egraph/examples/allocprobe.rs
@@ -213,11 +213,14 @@ fn probe(name: &str, semi: bool, limit: usize, build: impl Fn() -> (EG, Vec<Rule
     let peak_before = PEAK.load(Ordering::Relaxed);
     PEAK.store(LIVE.load(Ordering::Relaxed), Ordering::Relaxed);
 
+    // The probe's rules are total on their operands, so a fault here is the
+    // probe being wrong about its own inputs, not a result to report.
     let r = if semi {
         semi_persistent_egraph::saturate::saturate_semi(&rules, &mut eg, &NiraModel, limit, &g)
     } else {
         semi_persistent_egraph::saturate::saturate(&rules, &mut eg, &NiraModel, limit, &g)
-    };
+    }
+    .expect("probe rules are total");
 
     let after = snap();
     let peak = PEAK.load(Ordering::Relaxed);

--- a/egraph/examples/complsite.rs
+++ b/egraph/examples/complsite.rs
@@ -55,7 +55,8 @@ fn main() {
     for _ in 0..reps {
         let mut eg = ac_completion(pairs);
         let t = std::time::Instant::now();
-        let r = saturate(&[], &mut eg, &NiraModel, 1, &g);
+        // No rules, so nothing can evaluate a primitive, let alone fault.
+        let r = saturate(&[], &mut eg, &NiraModel, 1, &g).expect("no rules to fault");
         let dt = t.elapsed().as_secs_f64() * 1e3;
         acc += r.iterations + eg.node_count();
         best = best.min(dt);

--- a/egraph/src/apply.rs
+++ b/egraph/src/apply.rs
@@ -566,8 +566,20 @@ where
         }
         RhsOp::App { op: o, args } => {
             let mut children = ChildVec::<Cfg>::new();
-            for arg in args {
-                eval_arg(arg, env, eg, model, globals, &mut children)?;
+            // A right-hand side is a syntax tree too, so a rule written
+            // `(rewrite ... (F (F x y) z))` carries the same nested same-op application the
+            // interpreter's `push_seq_args` flattens for a ground term, and it needs the same
+            // treatment for the same reason: `EGraph::add` only ever sees ids and cannot tell
+            // a nested application from a class id that happens to be a `Seq` node.
+            match eg.ops().info(*o).kind {
+                crate::registry::OpKind::A { dir, .. } => {
+                    eval_seq_args(args, *o, dir, env, eg, model, globals, &mut children)?
+                }
+                _ => {
+                    for arg in args {
+                        eval_arg(arg, env, eg, model, globals, &mut children)?;
+                    }
+                }
             }
             eg.add(*o, &children)
         }
@@ -598,6 +610,62 @@ where
             eg.add_lit(lit_op, result_id)
         }
     })
+}
+
+/// Evaluate the argument list of an A-only right-hand-side application, splicing a nested
+/// same-`op` application on the declared spine instead of building it as one child.
+///
+/// The RHS counterpart of `Interp::push_seq_args`, and deliberately the same shape: for an
+/// associative operator `(F (F x y) z)` and `(F x y z)` are one term, and this is the last
+/// point at which that is visible, because after evaluation a child is a plain id.
+///
+/// Only [`RhsArg::One`] is spliced. A `..rest` splice or comprehension contributes many
+/// children whose own nesting was already resolved when those children were built, and an
+/// output multiplicity on a nested application asks for *n copies of that application*, which
+/// is not the same request as flattening it — both stay one argument.
+///
+/// [`AssocDir`](crate::registry::AssocDir) is honoured: off the declared spine a nested
+/// application is explicit grouping that the operator does not flatten, so for a left fold
+/// `a - (b - c)` must not become `a - b - c`. Index-based spine detection is exact for the
+/// positions actually spliced, since a `One` argument contributes exactly one child.
+#[allow(clippy::too_many_arguments)]
+fn eval_seq_args<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
+    args: &[RhsArg<Cfg::O, L>],
+    op: Cfg::O,
+    dir: crate::registry::AssocDir,
+    env: &mut RhsEnv<'_, Cfg, Q>,
+    eg: &mut EGraph<Cfg, L, T, P>,
+    model: &M,
+    globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
+    out: &mut ChildVec<Cfg>,
+) -> Result<(), EvalError>
+where
+    Cfg: EGraphConfig,
+    L: LitVal,
+    M: crate::lit_model::LitModel<Value = L>,
+    Q: crate::ematch::MatchView<Cfg> + ?Sized,
+    MSetCanon: VarCanon<Cfg::G, Cfg::C>,
+{
+    use crate::registry::AssocDir;
+    let last = args.len().saturating_sub(1);
+    for (i, arg) in args.iter().enumerate() {
+        let on_spine = match dir {
+            AssocDir::Both => true,
+            AssocDir::Left => i == 0,
+            AssocDir::Right => i == last,
+        };
+        match arg {
+            RhsArg::One(RhsOp::App {
+                op: inner_op,
+                args: inner,
+            }) if on_spine && *inner_op == op => {
+                // Recursive, so `(F (F (F x y) z) w)` flattens in one pass.
+                eval_seq_args(inner, op, dir, env, eg, model, globals, out)?;
+            }
+            _ => eval_arg(arg, env, eg, model, globals, out)?,
+        }
+    }
+    Ok(())
 }
 
 fn eval_arg<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(

--- a/egraph/src/apply.rs
+++ b/egraph/src/apply.rs
@@ -10,6 +10,7 @@ use crate::ast::{
     GlobalVarId, LitValVarId, MsetVarId, RhsLocalMultVarId, RhsLocalVarId, SeqVarId, SetVarId,
 };
 use crate::containers::DenseId;
+use crate::lit_model::{EvalError, EvalSite};
 use crate::resolve::{RRhsChild, RRhsTerm, RhsMultRef, RhsNodeRef};
 
 // ---------------------------------------------------------------------------
@@ -528,13 +529,18 @@ fn mult_as_lit<L: LitVal, M: crate::lit_model::LitModel<Value = L>>(model: &M, k
     (desc.parse)(&k.to_string()).expect("multiplicity in RHS does not fit i64")
 }
 
+/// Build the term an RHS operator denotes, in `eg`.
+///
+/// `Err` is a partial primitive applied outside its domain on this match (see
+/// [`EvalError`]). There is no term to return in that case and no defensible
+/// substitute, so the error travels out instead of being absorbed.
 fn eval<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
     op: &RhsOp<Cfg::O, L>,
     env: &mut RhsEnv<'_, Cfg, Q>,
     eg: &mut EGraph<Cfg, L, T, P>,
     model: &M,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> Cfg::G
+) -> Result<Cfg::G, EvalError>
 where
     Cfg: EGraphConfig,
     L: LitVal,
@@ -542,7 +548,7 @@ where
     Q: crate::ematch::MatchView<Cfg> + ?Sized,
     MSetCanon: VarCanon<Cfg::G, Cfg::C>,
 {
-    match op {
+    Ok(match op {
         RhsOp::FetchNode(node) => eg.find(env.node(*node)),
         RhsOp::FetchGlobal(gid) => eg.find(globals.binding(*gid)),
         RhsOp::Lit(op, val) => {
@@ -561,7 +567,7 @@ where
         RhsOp::App { op: o, args } => {
             let mut children = ChildVec::<Cfg>::new();
             for arg in args {
-                eval_arg(arg, env, eg, model, globals, &mut children);
+                eval_arg(arg, env, eg, model, globals, &mut children)?;
             }
             eg.add(*o, &children)
         }
@@ -581,7 +587,8 @@ where
                 .collect();
             let refs: SmallVec<[&L; PRIM_ARGS]> = raw_vals.iter().collect();
             let prim = &model.ops()[op.to_usize()];
-            let result = (prim.eval)(&refs);
+            let result = (prim.eval)(&refs)
+                .ok_or_else(|| EvalError::new(prim.name, &refs, EvalSite::Rhs))?;
             let result_id = eg.lits_mut().intern(result);
             // Find the @-prefixed lit op for the return sort
             let lit_op = eg
@@ -590,7 +597,7 @@ where
                 .expect("no lit op for prim op return sort");
             eg.add_lit(lit_op, result_id)
         }
-    }
+    })
 }
 
 fn eval_arg<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
@@ -600,7 +607,8 @@ fn eval_arg<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
     model: &M,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
     out: &mut ChildVec<Cfg>,
-) where
+) -> Result<(), EvalError>
+where
     Cfg: EGraphConfig,
     L: LitVal,
     M: crate::lit_model::LitModel<Value = L>,
@@ -614,16 +622,17 @@ fn eval_arg<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
         // match bindings. Going through `eval` would `find` each child twice.
         RhsArg::One(RhsOp::FetchNode(node)) => out.push(env.node(*node)),
         RhsArg::One(RhsOp::FetchGlobal(gid)) => out.push(globals.binding(*gid)),
-        RhsArg::One(inner) => out.push(eval(inner, env, eg, model, globals)),
+        RhsArg::One(inner) => out.push(eval(inner, env, eg, model, globals)?),
         RhsArg::OneMult { body, mult } => {
             // Multiplicity 0 omits the child without evaluating it, so an
             // omitted term is never materialized (the k-1 = 0 case of a
             // multiplicity variant). Underflow and division by zero were rejected
             // at install by the interval check; the checked ops here are the
-            // second line, like the checked literal primitives.
-            let k = eval_mult_expr::<Cfg, Q>(mult, env);
+            // second line, like the checked literal primitives, and report the
+            // same way.
+            let k = eval_mult_expr::<Cfg, Q>(mult, env)?;
             if k > 0 {
-                let id = eval(body, env, eg, model, globals);
+                let id = eval(body, env, eg, model, globals)?;
                 for _ in 0..k {
                     out.push(id);
                 }
@@ -651,14 +660,14 @@ fn eval_arg<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
             let source = env.query.seq_slice(*source).to_vec();
             for child in source {
                 let previous = env.bind_local_node(*var, child);
-                let passes = filter.as_ref().is_none_or(|filter| {
-                    let value = eval(filter, env, eg, model, globals);
-                    check_filter_truthy(eg, model, value)
-                });
-                if passes {
-                    out.push(eval(body, env, eg, model, globals));
-                }
+                // The binding is restored on the error path too: `?` here would
+                // leave the comprehension variable bound, and `locals_are_unbound`
+                // asserts it is not.
+                let outcome = eval_comp_element(body, filter, env, eg, model, globals);
                 env.restore_local_node(*var, previous);
+                if let Some(id) = outcome? {
+                    out.push(id);
+                }
             }
         }
         RhsArg::SetComp {
@@ -670,14 +679,14 @@ fn eval_arg<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
             let source = env.query.set_slice(*source).to_vec();
             for child in source {
                 let previous = env.bind_local_node(*var, child);
-                let passes = filter.as_ref().is_none_or(|filter| {
-                    let value = eval(filter, env, eg, model, globals);
-                    check_filter_truthy(eg, model, value)
-                });
-                if passes {
-                    out.push(eval(body, env, eg, model, globals));
-                }
+                // The binding is restored on the error path too: `?` here would
+                // leave the comprehension variable bound, and `locals_are_unbound`
+                // asserts it is not.
+                let outcome = eval_comp_element(body, filter, env, eg, model, globals);
                 env.restore_local_node(*var, previous);
+                if let Some(id) = outcome? {
+                    out.push(id);
+                }
             }
         }
         RhsArg::MsetComp {
@@ -692,68 +701,136 @@ fn eval_arg<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
             for child in source {
                 let previous_node = env.bind_local_node(*var, Cfg::mset_child_id(&child));
                 let previous_mult = env.bind_local_mult(*mult_var, Cfg::mset_child_mult(&child));
-                let passes = filter.as_ref().is_none_or(|filter| {
-                    let value = eval(filter, env, eg, model, globals);
-                    check_filter_truthy(eg, model, value)
-                });
-                if passes {
-                    let count = eval_mult_expr::<Cfg, Q>(out_mult, env);
-                    if count != 0 {
-                        let result = eval(body, env, eg, model, globals);
-                        // Install-time checks guarantee that every emitted
-                        // multiplicity fits the configured storage width.
-                        let count = Cfg::M::try_from_u64(count)
-                            .expect("RHS multiplicity exceeds the configured width");
-                        for _ in 0..count.to_usize() {
-                            out.push(result);
-                        }
-                    }
-                }
+                // Unbind before propagating, as in the seq/set arms above.
+                let outcome =
+                    eval_mset_comp_element(body, out_mult, filter, env, eg, model, globals);
                 env.restore_local_mult(*mult_var, previous_mult);
                 env.restore_local_node(*var, previous_node);
+                if let Some((result, count)) = outcome? {
+                    for _ in 0..count.to_usize() {
+                        out.push(result);
+                    }
+                }
             }
         }
     }
+    Ok(())
+}
+
+/// One element of a `SeqComp`/`SetComp`: `None` when the filter rejects it.
+///
+/// Split out so `eval_arg` can restore the comprehension variable before
+/// propagating an error; the body would otherwise need the binding live across a
+/// `?`.
+fn eval_comp_element<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
+    body: &RhsOp<Cfg::O, L>,
+    filter: &Option<Box<RhsOp<Cfg::O, L>>>,
+    env: &mut RhsEnv<'_, Cfg, Q>,
+    eg: &mut EGraph<Cfg, L, T, P>,
+    model: &M,
+    globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
+) -> Result<Option<Cfg::G>, EvalError>
+where
+    Cfg: EGraphConfig,
+    L: LitVal,
+    M: crate::lit_model::LitModel<Value = L>,
+    Q: crate::ematch::MatchView<Cfg> + ?Sized,
+    MSetCanon: VarCanon<Cfg::G, Cfg::C>,
+{
+    if let Some(filter) = filter {
+        let value = eval(filter, env, eg, model, globals)?;
+        if !check_filter_truthy(eg, model, value) {
+            return Ok(None);
+        }
+    }
+    Ok(Some(eval(body, env, eg, model, globals)?))
+}
+
+/// One element of an `MsetComp`: `None` when the filter rejects it or the output
+/// multiplicity is zero, otherwise the term and how many copies to emit.
+fn eval_mset_comp_element<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
+    body: &RhsOp<Cfg::O, L>,
+    out_mult: &crate::resolve::ResolvedMultExpr,
+    filter: &Option<Box<RhsOp<Cfg::O, L>>>,
+    env: &mut RhsEnv<'_, Cfg, Q>,
+    eg: &mut EGraph<Cfg, L, T, P>,
+    model: &M,
+    globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
+) -> Result<Option<(Cfg::G, Cfg::M)>, EvalError>
+where
+    Cfg: EGraphConfig,
+    L: LitVal,
+    M: crate::lit_model::LitModel<Value = L>,
+    Q: crate::ematch::MatchView<Cfg> + ?Sized,
+    MSetCanon: VarCanon<Cfg::G, Cfg::C>,
+{
+    if let Some(filter) = filter {
+        let value = eval(filter, env, eg, model, globals)?;
+        if !check_filter_truthy(eg, model, value) {
+            return Ok(None);
+        }
+    }
+    let count = eval_mult_expr::<Cfg, Q>(out_mult, env)?;
+    if count == 0 {
+        return Ok(None);
+    }
+    // `check_mult_literals` rejects a rule whose *literal* multiplicities
+    // overflow the configured width at install, but a computed one (`k+k`, or a
+    // `k` from a wider surface width) is only known here. It is a program error
+    // like any other partial operation, so it is reported rather than asserted:
+    // narrowing is decided by `try_from_u64`, never by truncation.
+    let count = Cfg::M::try_from_u64(count).ok_or_else(|| EvalError {
+        op: "multiplicity",
+        args: vec![count.to_string()],
+        site: EvalSite::Multiplicity,
+        rule: None,
+    })?;
+    let result = eval(body, env, eg, model, globals)?;
+    Ok(Some((result, count)))
 }
 
 /// Evaluate an RHS multiplicity expression over the match's bound
-/// multiplicities, in checked u64 arithmetic. Underflow and division by zero
-/// are rejected statically at rule install ([`check_rhs_mult_exprs`]); the
-/// checked ops here are the second line, and panic like the checked literal
-/// primitives do.
-fn eval_mult_expr<Cfg, Q>(e: &crate::resolve::ResolvedMultExpr, env: &RhsEnv<'_, Cfg, Q>) -> u64
+/// multiplicities, in checked u64 arithmetic.
+///
+/// Underflow and division by zero are rejected statically at rule install
+/// ([`check_rhs_mult_exprs`]), so reaching them here would be an install-check
+/// bug; overflow is genuinely reachable, because rejecting every expression that
+/// could overflow an unbounded `k` would ban `k+1`. All three report the same
+/// way, for the same reason the literal primitives do: there is no multiplicity
+/// to return, and emitting a different number of copies than the rule asks for
+/// would silently change what the rule means.
+fn eval_mult_expr<Cfg, Q>(
+    e: &crate::resolve::ResolvedMultExpr,
+    env: &RhsEnv<'_, Cfg, Q>,
+) -> Result<u64, EvalError>
 where
     Cfg: EGraphConfig,
     Q: crate::ematch::MatchView<Cfg> + ?Sized,
 {
     use crate::resolve::{MultPrimOp as P, ResolvedMultExpr as E};
-    match e {
+    Ok(match e {
         E::Lit(n) => *n,
         E::Var(v) => env.mult(*v).to_u64(),
         E::Prim { op, args } => {
-            let a = eval_mult_expr::<Cfg, Q>(&args[0], env);
-            let b = eval_mult_expr::<Cfg, Q>(&args[1], env);
+            let a = eval_mult_expr::<Cfg, Q>(&args[0], env)?;
+            let b = eval_mult_expr::<Cfg, Q>(&args[1], env)?;
+            let fault = |name: &'static str| EvalError {
+                op: name,
+                args: vec![a.to_string(), b.to_string()],
+                site: EvalSite::Multiplicity,
+                rule: None,
+            };
             match op {
-                P::Add => a
-                    .checked_add(b)
-                    .expect("u64::+ overflow in RHS multiplicity"),
-                P::Sub => a
-                    .checked_sub(b)
-                    .expect("u64::- underflow in RHS multiplicity"),
-                P::Mul => a
-                    .checked_mul(b)
-                    .expect("u64::* overflow in RHS multiplicity"),
-                P::Div => a
-                    .checked_div(b)
-                    .expect("u64::/ by zero in RHS multiplicity"),
-                P::Rem => a
-                    .checked_rem(b)
-                    .expect("u64::% by zero in RHS multiplicity"),
+                P::Add => a.checked_add(b).ok_or_else(|| fault("u64::+"))?,
+                P::Sub => a.checked_sub(b).ok_or_else(|| fault("u64::-"))?,
+                P::Mul => a.checked_mul(b).ok_or_else(|| fault("u64::*"))?,
+                P::Div => a.checked_div(b).ok_or_else(|| fault("u64::/"))?,
+                P::Rem => a.checked_rem(b).ok_or_else(|| fault("u64::%"))?,
                 P::Min => a.min(b),
                 P::Max => a.max(b),
             }
         }
-    }
+    })
 }
 
 /// Interval bounds of an RHS multiplicity expression, from the rule's LHS
@@ -762,7 +839,7 @@ where
 /// *wrong* at runtime rather than merely large: a subtraction that cannot be
 /// proved non-negative, and a division or remainder whose divisor could be
 /// zero. Additions and products saturate in the bound computation; a runtime
-/// overflow still traps in [`eval_mult_expr`].
+/// overflow is still reported by [`eval_mult_expr`].
 fn mult_expr_bounds(
     e: &crate::resolve::ResolvedMultExpr,
     intervals: &[(crate::ast::MultVarId, u64, u64)],
@@ -813,11 +890,12 @@ fn mult_expr_bounds(
 }
 
 /// Static safety check for every RHS multiplicity expression in a rule's
-/// actions, against the rule's LHS multiplicity intervals. Rejection here is
-/// what licenses the `expect`s in `eval_mult_expr` for underflow and
-/// division by zero; overflow stays a runtime trap because any expression
-/// over an unbounded `k` could overflow and rejecting them all would ban
-/// `k+1`.
+/// actions, against the rule's LHS multiplicity intervals. Rejection here turns
+/// underflow and division by zero into an install-time diagnostic naming the
+/// multiplicity to constrain, which is far more useful than the same fault
+/// surfacing mid-saturation; overflow stays a runtime report because any
+/// expression over an unbounded `k` could overflow and rejecting them all would
+/// ban `k+1`.
 pub fn check_rhs_mult_exprs<O, S, V>(rule: &PreparedRule<O, S, V>) -> Result<(), String> {
     fn walk_op<O, V>(
         op: &RhsOp<O, V>,
@@ -896,7 +974,7 @@ fn apply_action<Cfg, L, M, Q, S: Copy, const T: bool, const P: bool>(
     eg: &mut EGraph<Cfg, L, T, P>,
     model: &M,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> usize
+) -> Result<usize, EvalError>
 where
     Cfg: EGraphConfig,
     L: LitVal,
@@ -904,10 +982,10 @@ where
     Q: crate::ematch::MatchView<Cfg> + ?Sized,
     MSetCanon: VarCanon<Cfg::G, Cfg::C>,
 {
-    match action {
+    Ok(match action {
         CompiledAction::Union(rule_id, a, b) => {
-            let va = eval(a, env, eg, model, globals);
-            let vb = eval(b, env, eg, model, globals);
+            let va = eval(a, env, eg, model, globals)?;
+            let vb = eval(b, env, eg, model, globals)?;
             if eg.find(va) != eg.find(vb) {
                 if P {
                     eg.merge_justified(
@@ -924,7 +1002,7 @@ where
             }
         }
         CompiledAction::Insert(t) => {
-            eval(t, env, eg, model, globals);
+            eval(t, env, eg, model, globals)?;
             1
         }
         CompiledAction::Set {
@@ -939,7 +1017,7 @@ where
             eg.subsume(node);
             1
         }
-    }
+    })
 }
 
 pub(crate) fn apply_rule_actions<Cfg, L, M, Q, S, const T: bool, const P: bool>(
@@ -948,7 +1026,7 @@ pub(crate) fn apply_rule_actions<Cfg, L, M, Q, S, const T: bool, const P: bool>(
     eg: &mut EGraph<Cfg, L, T, P>,
     model: &M,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> usize
+) -> Result<usize, EvalError>
 where
     Cfg: EGraphConfig,
     S: Copy,
@@ -958,16 +1036,30 @@ where
     MSetCanon: VarCanon<Cfg::G, Cfg::C>,
 {
     let mut env = RhsEnv::new(query, rule.rhs_locals);
-    let changes = rule
-        .actions
-        .iter()
-        .map(|action| apply_action(action, &mut env, eg, model, globals))
-        .sum();
+    // Actions are applied in order and an error stops at the one that faulted:
+    // the earlier actions' effects stay in the e-graph. That is deliberate. The
+    // run is over, so nothing reads the graph again except a diagnostic, and
+    // undoing them would need a rollback point per action for a case that ends
+    // the program either way.
+    let mut changes = 0;
+    let mut faulted = None;
+    for action in &rule.actions {
+        match apply_action(action, &mut env, eg, model, globals) {
+            Ok(n) => changes += n,
+            Err(e) => {
+                faulted = Some(e);
+                break;
+            }
+        }
+    }
     debug_assert!(
         env.locals_are_unbound(),
         "RHS comprehension locals must not escape action evaluation"
     );
-    changes
+    match faulted {
+        Some(e) => Err(e),
+        None => Ok(changes),
+    }
 }
 
 pub fn apply_rule<Cfg, L, M, S, const T: bool, const P: bool>(
@@ -977,7 +1069,7 @@ pub fn apply_rule<Cfg, L, M, S, const T: bool, const P: bool>(
     stats: &crate::schedule::IndexStats<Cfg::O>,
     model: &M,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> usize
+) -> Result<usize, EvalError>
 where
     Cfg: EGraphConfig,
     S: crate::DenseId,
@@ -1009,7 +1101,7 @@ pub fn apply_rule_pooled<Cfg, L, M, S, const T: bool, const P: bool>(
     model: &M,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
     pool: &mut MatchPool<Cfg>,
-) -> usize
+) -> Result<usize, EvalError>
 where
     Cfg: EGraphConfig,
     S: crate::DenseId,
@@ -1021,12 +1113,37 @@ where
     let sampler = crate::index::IndexSampler::new(eg, vindex);
     let plan = crate::schedule::schedule_with_stats_sampled(&rule.query, stats, &sampler);
     run_query_scheduled_into(&rule.query, &plan, eg, &vindex, globals, pool);
+    // A guard fault is checked before the actions run. The matcher dropped the
+    // assignment it was found on, so applying the surviving matches would be
+    // deriving from a query the engine could not fully evaluate.
+    if let Some(fault) = pool.guard_fault() {
+        return Err(name_fault(fault.clone(), rule, eg));
+    }
     let mut changes = 0;
     for j in 0..pool.len() {
         let row = pool.row(j);
-        changes += apply_rule_actions(rule, &row, eg, model, globals);
+        match apply_rule_actions(rule, &row, eg, model, globals) {
+            Ok(n) => changes += n,
+            Err(e) => return Err(name_fault(e, rule, eg)),
+        }
     }
-    changes
+    Ok(changes)
+}
+
+/// Attribute a fault to the rule that hit it, by the name the rule was
+/// registered under. The evaluators only see the operation, and a `RuleId` alone
+/// tells the reader nothing.
+pub(crate) fn name_fault<Cfg, L, S, O, const T: bool, const P: bool>(
+    fault: EvalError,
+    rule: &PreparedRule<O, S, L>,
+    eg: &EGraph<Cfg, L, T, P>,
+) -> EvalError
+where
+    Cfg: EGraphConfig,
+    L: LitVal,
+    MSetCanon: VarCanon<Cfg::G, Cfg::C>,
+{
+    fault.in_rule(eg.rules().name(rule.rule_id))
 }
 
 #[cfg(test)]
@@ -1621,7 +1738,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0, "expected at least one change");
 
         // After: (f b a) should exist and be merged with (f a b)
@@ -1671,7 +1789,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0);
 
         // (g (f b a)) should now exist and be merged with (f a (g b))
@@ -1716,7 +1835,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert_eq!(changes, 0);
     }
 
@@ -1757,7 +1877,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0);
 
         // (h a b) should exist and be in same e-class as (f a b)
@@ -1810,7 +1931,9 @@ mod tests {
                 &crate::schedule::IndexStats::from_index(&index),
                 &model,
                 &globals,
-            ) > 0
+            )
+            .unwrap()
+                > 0
         );
         assert_eq!(
             eg.op_node_counts()[count_f.to_usize()],
@@ -1858,7 +1981,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert_eq!(changes, 1);
 
         // (h a b) should exist but NOT be merged with (f a b)
@@ -1913,7 +2037,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0);
 
         // (concat a a b c) should be merged with (concat a b c)
@@ -1959,7 +2084,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0);
 
         // For match x=a, rest={b}: {add (g a) b} merged with {add a b}
@@ -2006,7 +2132,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0);
 
         let ga = eg.add(eg.ops().id_by_name("g").unwrap(), &[a]);
@@ -2066,7 +2193,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0, "constant fold should fire");
 
         // (ILit (@IBig 8)) should now be merged with (IAdd (ILit 3) (ILit 5))
@@ -2123,7 +2251,8 @@ mod tests {
             &crate::schedule::IndexStats::from_index(&index),
             &model,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
         assert!(changes > 0);
         eg.rebuild();
 

--- a/egraph/src/apply.rs
+++ b/egraph/src/apply.rs
@@ -186,6 +186,12 @@ pub struct PreparedRule<O, S, V> {
     /// The ruleset this rule belongs to (`:ruleset name`), or `None` for the default one.
     /// The saturation driver runs the rules whose ruleset equals the one asked for.
     pub ruleset: Option<RulesetId>,
+    /// Source span of the rule's left-hand side, or [`Span::Dummy`] for a rule built by an
+    /// API caller rather than parsed. Carried only for diagnostics: a primitive that faults
+    /// while this rule is applying can then name the line the rule was written on, instead of
+    /// only the generated rule name (`rewrite_0`), which tells a reader nothing about where to
+    /// look. Nothing in matching or application reads it.
+    pub span: crate::ast::Span,
 }
 
 // ---------------------------------------------------------------------------
@@ -382,6 +388,7 @@ where
         rhs_locals,
         actions,
         ruleset: None,
+        span: lhs.span(),
     })
 }
 
@@ -425,6 +432,7 @@ where
         rhs_locals,
         actions,
         ruleset: None,
+        span: body.first().map_or(crate::ast::Span::Dummy, |p| p.span()),
     })
 }
 
@@ -848,6 +856,7 @@ where
     // like any other partial operation, so it is reported rather than asserted:
     // narrowing is decided by `try_from_u64`, never by truncation.
     let count = Cfg::M::try_from_u64(count).ok_or_else(|| EvalError {
+        span: crate::ast::Span::Dummy,
         op: "multiplicity",
         args: vec![count.to_string()],
         site: EvalSite::Multiplicity,
@@ -883,6 +892,7 @@ where
             let a = eval_mult_expr::<Cfg, Q>(&args[0], env)?;
             let b = eval_mult_expr::<Cfg, Q>(&args[1], env)?;
             let fault = |name: &'static str| EvalError {
+                span: crate::ast::Span::Dummy,
                 op: name,
                 args: vec![a.to_string(), b.to_string()],
                 site: EvalSite::Multiplicity,
@@ -1211,7 +1221,7 @@ where
     L: LitVal,
     MSetCanon: VarCanon<Cfg::G, Cfg::C>,
 {
-    fault.in_rule(eg.rules().name(rule.rule_id))
+    fault.in_rule(eg.rules().name(rule.rule_id)).at(rule.span)
 }
 
 #[cfg(test)]

--- a/egraph/src/ast.rs
+++ b/egraph/src/ast.rs
@@ -64,6 +64,97 @@ impl Span {
     pub const fn new(start: u32, end: u32) -> Self {
         Self::Range { start, end }
     }
+
+    /// 1-based `(line, column)` of this span's start in `src`, or `None` for
+    /// [`Span::Dummy`] or an offset past the end of `src`.
+    ///
+    /// Byte offsets are what the parser records and what a `Display` on an error type can
+    /// print without holding the source; a line and column are what a person reading a
+    /// terminal can act on. Diagnostics therefore keep the offset and convert here, at the
+    /// one place that has the source text: [`render_in`](Self::render_in), called from the
+    /// binary's top-level error reporting.
+    ///
+    /// The column counts UTF-8 *characters*, not bytes, so a line with multi-byte text still
+    /// reports a column a reader can count to. Cost is one scan of the prefix, which is
+    /// irrelevant on a path that runs once, as the program is about to exit.
+    pub fn line_col(&self, src: &str) -> Option<(usize, usize)> {
+        let Span::Range { start, .. } = *self else {
+            return None;
+        };
+        let start = start as usize;
+        if start > src.len() {
+            return None;
+        }
+        let prefix = &src[..start];
+        let line = prefix.matches('\n').count() + 1;
+        let col = prefix
+            .rfind('\n')
+            .map_or(prefix, |nl| &prefix[nl + 1..])
+            .chars()
+            .count()
+            + 1;
+        Some((line, col))
+    }
+
+    /// `"line L column C"` for a resolvable span, else `None`.
+    ///
+    /// Returning `Option` rather than an empty string keeps the caller in charge of how a
+    /// missing location reads in its own message, instead of leaving a dangling " at ".
+    pub fn render_in(&self, src: &str) -> Option<String> {
+        self.line_col(src)
+            .map(|(l, c)| format!("line {l} column {c}"))
+    }
+}
+
+#[cfg(test)]
+mod span_tests {
+    use super::Span;
+
+    #[test]
+    fn line_col_is_one_based_on_the_first_line() {
+        let src = "(sort E)\n(constructor a () E)\n";
+        assert_eq!(Span::new(0, 4).line_col(src), Some((1, 1)));
+        assert_eq!(Span::new(6, 7).line_col(src), Some((1, 7)));
+    }
+
+    #[test]
+    fn line_col_counts_newlines_and_restarts_the_column() {
+        let src = "(sort E)\n(constructor a () E)\n";
+        // Offset 9 is the '(' that opens line 2.
+        assert_eq!(Span::new(9, 20).line_col(src), Some((2, 1)));
+        assert_eq!(Span::new(21, 22).line_col(src), Some((2, 13)));
+    }
+
+    #[test]
+    fn column_counts_characters_not_bytes() {
+        // 'é' is two bytes, so a byte-based column would report 4 rather than 3.
+        let src = "aé b";
+        assert_eq!(Span::new(3, 4).line_col(src), Some((1, 3)));
+    }
+
+    #[test]
+    fn dummy_and_out_of_range_do_not_resolve() {
+        let src = "(sort E)";
+        assert_eq!(Span::Dummy.line_col(src), None);
+        assert_eq!(Span::Dummy.render_in(src), None);
+        assert_eq!(Span::new(999, 1000).line_col(src), None);
+    }
+
+    #[test]
+    fn offset_at_end_of_source_resolves() {
+        // A span pointing just past the last byte is the EOF position, not an error.
+        let src = "(sort E)";
+        assert_eq!(Span::new(8, 8).line_col(src), Some((1, 9)));
+    }
+
+    #[test]
+    fn render_in_is_human_readable() {
+        let src = "a\nbb\nccc";
+        assert_eq!(
+            Span::new(5, 6).render_in(src).as_deref(),
+            Some("line 3 column 1")
+        );
+    }
 }
 
 /// Multiplicity constraint on an AC element.

--- a/egraph/src/egraph.rs
+++ b/egraph/src/egraph.rs
@@ -3454,6 +3454,21 @@ where
     /// Cost is one class-ring walk, with an early exit on the first non-`op` member — so an
     /// ordinary atom child (a leaf, a constructor) costs its class's first member, and the
     /// full walk is paid only by classes that really are pure sequences.
+    ///
+    /// **Purity is monotone-false: it *closes*, it does not merely fail to open.** A union
+    /// only adds members, so a class that is a pure `op`-sequence today can stop being one
+    /// tomorrow and can never become one again. This test is therefore a function of the
+    /// class *at the moment it is asked*, not of the term, and asking it at two different
+    /// times is what used to make `(union (F a b) blob)` before `(F (F a b) c)` store the
+    /// nested spelling while the reverse order stored the flat one.
+    ///
+    /// That is why this test is no longer the only one on the build path.
+    /// [`push_seq_args`](crate::interpret::Interp::push_seq_args) in the term builder decides
+    /// the written nesting from the syntax first, where no class can reach it, and this test
+    /// then handles what is left: a child that came back from `add` already flattenable. Do
+    /// not try to move the syntactic case here or into `add` — by this point a child is a
+    /// plain `Cfg::G`, and a nested application is indistinguishable from a class id that
+    /// happens to be a `Seq` node, which is what RHS rest bindings supply.
     fn pure_seq_node(&self, g: Cfg::G, op: Cfg::O) -> Option<Cfg::G> {
         let cls = self.classes.find_const(g);
         let mut best: Option<Cfg::G> = None;

--- a/egraph/src/egraph.rs
+++ b/egraph/src/egraph.rs
@@ -137,6 +137,12 @@ pub struct EGraph<
     /// [`set_completion_node_budget`](Self::set_completion_node_budget) (tests use a tiny
     /// budget to exercise the abort path directly).
     completion_node_budget: usize,
+    /// `(touched.len(), num_classes)` as of the last [`canon_repair_round`](EGraph::canon_repair_round)
+    /// that found nothing. While both are unchanged no node was created or recanonicalized
+    /// and no classes merged, so the round cannot find anything and is skipped. Transient
+    /// scratch, not semi-persistent state: `restore` clears it, so a rolled-back graph is
+    /// always rescanned.
+    repair_state: Option<(usize, usize)>,
 }
 
 /// Default node-growth budget for one completion-enabled `rebuild` (see
@@ -263,6 +269,7 @@ where
             inverse_op: crate::containers::SpMap::new(),
             completion_outcome: None,
             completion_node_budget: DEFAULT_COMPLETION_NODE_BUDGET,
+            repair_state: None,
         }
     }
 
@@ -1651,7 +1658,20 @@ where
         // Ordinary atom-level congruence closure always runs. AC completion runs only
         // when opted in (default off for divergence scoping — see the `cc` field docs).
         if !self.cc {
-            self.rebuild_congruence();
+            // Canonization repair runs in plain mode too: it does not derive AC
+            // consequences, it supplies the equalities the canonization laws already
+            // *state* but whose stored spelling `add` chose from a non-monotone predicate
+            // (see `canon_repair_round`). Its merges feed congruence, so the two run to a
+            // joint fixpoint, bounded by the node-growth budget.
+            // No budget on this loop: the repair is purely subtractive (inverse-pair
+            // cancellation), so each of its merges strictly reduces the class count and the
+            // fixpoint is bounded by the number of classes.
+            loop {
+                self.rebuild_congruence();
+                if !self.canon_repair_round() {
+                    break;
+                }
+            }
             self.completion_outcome = Some(CompletionOutcome::Disabled);
             return;
         }
@@ -1712,7 +1732,8 @@ where
             let was_full = full;
             // `|`, not `||`: the A-only pass runs every iteration, its changes
             // and the AC round's alike drain through the same fixpoint.
-            let changed = self.cc_round(full, prev_mark, mark) | self.a_round();
+            let changed =
+                self.cc_round(full, prev_mark, mark) | self.a_round() | self.canon_repair_round();
             prev_mark = mark;
             if trace {
                 eprintln!(
@@ -2044,6 +2065,159 @@ where
                 }
                 break;
             }
+        }
+        changed
+    }
+
+    /// One canonization-repair round: re-apply the canonization law whose applicability
+    /// condition *opens* with later merges, so that applying it stays a function of the
+    /// e-graph rather than of statement order. Returns `true` if it scheduled any merge (the
+    /// caller drains congruence and calls again). Runs in every mode, plain included.
+    ///
+    /// # What this does and does not repair
+    ///
+    /// `add` decides each child's stored spelling once, from a predicate over the child's
+    /// *class* at that moment, and those predicates are monotone in one direction. Two
+    /// canonization laws are affected, and they need opposite treatment:
+    ///
+    /// | law | predicate | direction | reordering symptom |
+    /// | --- | --- | --- | --- |
+    /// | inverse cancel ([`group_cancel_pairs`](Self::group_cancel_pairs)) | `inv(x)`'s node resolves to a summand | **opens**: a later merge can create the pair | `(+ a (neg b))` built *before* `(union a b)` hides `+(a, neg(a)) = 0` |
+    /// | AC flatten ([`flatten_ac_children`](Self::flatten_ac_children)) | `¬atomic(c)` | **closes**: `atomic` is monotone-true | `+(*(d,d), a)` built *before* `*(a,d,*(d,d))` hides `*(a,d,d,d) = *(a,d,*(d,d))` |
+    ///
+    /// Only the first is repaired here. An opening condition means the law simply was not
+    /// tried at the moment it became applicable, and re-trying it costs nothing and can only
+    /// shrink a monomial. Plain mode already applies this law at build, so *not* re-applying
+    /// it leaves plain mode inconsistent with itself.
+    ///
+    /// The AC flatten row is deliberately **not** repaired, and the reason is worth recording
+    /// because it is not obvious. `atomic` answers "is this class used as a non-same-op child"
+    /// with *so far*; order independence would need it answered for the rest of the program,
+    /// which no build-time predicate can do. Every way of removing the dependence is worse:
+    /// always splice breaks `§5b`'s cancellation (`+(c, neg(c))` needs the pair to survive as
+    /// two summands), never splice regresses the flatten fixtures, and deciding syntactically
+    /// on inline-versus-by-name still breaks `§5b` for a `§5b` term written inline. Note that
+    /// `atomic` *is* order-independent within a single term, since argument evaluation fixes
+    /// the order; the dependence is only across statements, which is exactly the AC
+    /// incompleteness the eager and lazy modes exist to close (`--derive-ac-eqs` proves
+    /// `ac_flatten_order_dependence.egg`, plain declines it). Supplying the equality here
+    /// instead was measured at +73% nodes on `rhs_mult_expr` under `--derive-ac-eqs`, for a
+    /// consequence plain mode is not meant to derive.
+    ///
+    /// The A-only (`Seq`) analogue of the flatten row is a separate matter and *is* fixed, at
+    /// the source rather than here: [`splice_raw_seq_children`](Self::splice_raw_seq_children)
+    /// decides on the immutable child node id, so it mints nothing and cannot depend on merge
+    /// order. That works for `Seq` and not for AC because an A-only operator has no
+    /// `:identity` or `:inverse` (the property resolver rejects them without `:comm`), so no
+    /// `§5b` pair depends on the nested spelling being kept.
+    ///
+    /// # Termination
+    ///
+    /// Cancellation is purely subtractive and each repair merge strictly reduces the class
+    /// count, so the caller's fixpoint terminates with no growth budget and mints no node that
+    /// needs one.
+    fn canon_repair_round(&mut self) -> bool {
+        // Nothing to re-decide unless a node was created or recanonicalized (`touched` grew)
+        // or classes merged (`num_classes` fell) since the last round that found nothing.
+        // Both counters are cheap and monotone within a rebuild, so a `rebuild` on an
+        // unchanged graph — the common case for a run of `(check ...)` commands — costs two
+        // integer reads. `restore` resets the watermark, so a rolled-back graph is rescanned.
+        let state = (
+            self.touched.len(),
+            crate::containers::IndexLike::as_usize(self.classes.num_classes()),
+        );
+        if self.repair_state == Some(state) {
+            return false;
+        }
+        let changed = self.inverse_cancel_repair();
+        if !changed {
+            // Arm the skip only on a clean round. A round that merged left `touched` and
+            // `num_classes` moved, and the caller drains congruence and calls again.
+            self.repair_state = Some((
+                self.touched.len(),
+                crate::containers::IndexLike::as_usize(self.classes.num_classes()),
+            ));
+        }
+        changed
+    }
+
+    /// Merge helper for the repair passes: skip an already-joined pair, fold the
+    /// min-monomial pool, and queue the absorbed use-list for congruence. Mirrors
+    /// `cc_round`'s local `do_merge`.
+    fn repair_merge(&mut self, x: Cfg::G, y: Cfg::G, just: Justification<Cfg::G>) -> bool {
+        if self.classes.find_const(x) == self.classes.find_const(y) {
+            return false;
+        }
+        let m = if PROOFS {
+            self.merge_in_classes(x, y, Some(just))
+        } else {
+            self.merge_in_classes(x, y, None)
+        };
+        match m {
+            Some(m) => {
+                self.fold_min_monomial(m.survivor, m.absorbed_min_row, m.absorbed_atomic);
+                self.worklist.push((m.absorbed_uses, m.survivor));
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Re-apply inverse-pair cancellation (`x ∘ inv(x) = e`) to the stored MSet nodes.
+    ///
+    /// The build path cancels a pair only if the `inv(x)` node already existed *and* landed
+    /// in a summand class at that moment; a later merge can create the pair, and nothing
+    /// re-ran the law. `(+ a (neg b))` then `(union a b)` is the smallest witness: the node
+    /// recanonicalizes to `+{a, neg-class}` and `find(neg(a)) == find(neg(b))` holds by
+    /// congruence, but the summand pair is never cancelled, so `s = 0` is lost.
+    ///
+    /// Cancellation is purely subtractive, so unlike the two flatten laws it cannot grow a
+    /// node and needs no cap. MSet only, mirroring the build path (`add`'s Set arm does not
+    /// cancel). Free for a graph with no `:inverse` op.
+    fn inverse_cancel_repair(&mut self) -> bool {
+        // O(#ops) precheck, so a program with no group operator pays nothing.
+        let any_inverse = self.ops.mset_ops().any(|op| self.inverse_op(op).is_some());
+        if !any_inverse {
+            return false;
+        }
+        // Collect first, apply second: `add`/`merge` below mutate the node store that
+        // `completion_node_ids` walks.
+        let mut work: Vec<(Cfg::O, Cfg::G, Vec<(Cfg::G, Cfg::M)>)> = Vec::new();
+        let mut m: Vec<(Cfg::G, Cfg::M)> = Vec::new();
+        let ids: Vec<Cfg::G> = self.completion_node_ids().collect();
+        for gid in ids {
+            if !matches!(self.node_ref(gid), NodeRef::MSet(_)) {
+                continue;
+            }
+            let op = self.node_op(gid);
+            let Some(inv) = self.inverse_op(op) else {
+                continue;
+            };
+            self.node_monomial_into(gid, &mut m);
+            if self.group_cancel_pairs(inv, &mut m) {
+                work.push((op, gid, std::mem::take(&mut m)));
+            }
+        }
+        let mut buf: Vec<Cfg::G> = Vec::new();
+        let mut changed = false;
+        for (op, gid, ms) in work {
+            buf.clear();
+            for (g, mult) in &ms {
+                for _ in 0..mult.to_usize() {
+                    buf.push(*g);
+                }
+            }
+            // `add` resolves the degenerate results itself: a fully cancelled monomial is
+            // the unit (`+(a, neg(a)) → {} = 0`) and a single mult-1 residue is that class.
+            let c = self.add(op, &buf);
+            changed |= self.repair_merge(
+                c,
+                gid,
+                Justification::InverseCancel {
+                    node_a: c,
+                    node_b: gid,
+                },
+            );
         }
         changed
     }
@@ -2832,6 +3006,10 @@ where
         self.worklist.clear();
         self.collisions.clear();
         self.touched.clear();
+        // The repair watermark is a pair of counters over the *pre-restore* graph, and
+        // restore moves both (touched cleared, classes regrown). Drop it so the next
+        // `rebuild` rescans rather than trusting a comparison against a discarded state.
+        self.repair_state = None;
     }
 
     fn register_if_fresh(&mut self, result: Added<Cfg::G>, op: Cfg::O) -> Cfg::G {

--- a/egraph/src/egraph.rs
+++ b/egraph/src/egraph.rs
@@ -574,13 +574,17 @@ where
     }
 
     /// Saturate: apply rules to fixpoint or until `limit` iterations.
+    ///
+    /// `Err` is a rule that applied a partial primitive outside its domain; see
+    /// [`EvalError`](crate::lit_model::EvalError). Every `saturate*` entry point
+    /// here reports it the same way.
     pub fn saturate<M: crate::lit_model::LitModel<Value = L>, S: crate::DenseId + Copy>(
         &mut self,
         rules: &[crate::apply::PreparedRule<Cfg::O, S, L>],
         model: &M,
         limit: usize,
         globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-    ) -> crate::saturate::SatResult {
+    ) -> Result<crate::saturate::SatResult, crate::lit_model::EvalError> {
         crate::saturate::saturate(rules, self, model, limit, globals)
     }
 
@@ -592,7 +596,7 @@ where
         model: &M,
         limit: usize,
         globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-    ) -> crate::saturate::SatResult {
+    ) -> Result<crate::saturate::SatResult, crate::lit_model::EvalError> {
         crate::saturate::saturate_semi(rules, self, model, limit, globals)
     }
 
@@ -604,7 +608,7 @@ where
         model: &M,
         spec: &crate::saturate::RunSpec<Cfg::G>,
         globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-    ) -> crate::saturate::SatResult {
+    ) -> Result<crate::saturate::SatResult, crate::lit_model::EvalError> {
         crate::saturate::saturate_spec(rules, self, model, spec, globals)
     }
 
@@ -618,7 +622,7 @@ where
         model: &M,
         spec: &crate::saturate::RunSpec<Cfg::G>,
         globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-    ) -> crate::saturate::SatResult {
+    ) -> Result<crate::saturate::SatResult, crate::lit_model::EvalError> {
         crate::saturate::saturate_semi_spec(rules, self, model, spec, globals)
     }
 
@@ -632,7 +636,7 @@ where
         spec: &crate::saturate::RunSpec<Cfg::G>,
         globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
         scratch: &mut crate::index::IndexScratch<Cfg>,
-    ) -> crate::saturate::SatResult {
+    ) -> Result<crate::saturate::SatResult, crate::lit_model::EvalError> {
         crate::saturate::saturate_spec_in(rules, self, model, spec, globals, scratch)
     }
 
@@ -647,7 +651,7 @@ where
         spec: &crate::saturate::RunSpec<Cfg::G>,
         globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
         scratch: &mut crate::index::IndexScratch<Cfg>,
-    ) -> crate::saturate::SatResult {
+    ) -> Result<crate::saturate::SatResult, crate::lit_model::EvalError> {
         // Semi-naive is the one consumer of the merge-membership delta (see
         // `merge_in_classes`); the flag keeps the per-merge ring walks off
         // everywhere else.

--- a/egraph/src/ematch.rs
+++ b/egraph/src/ematch.rs
@@ -17,6 +17,7 @@ use crate::egraph::EGraph;
 use crate::index::{IndexMode, IndexStore, SortedVecCursor, VariantIndex};
 use crate::leapfrog::seek_stats::Probed;
 use crate::leapfrog::{CursorVec, Difference, LeapfrogJoin, SortedCursor};
+use crate::lit_model::{EvalError, EvalSite};
 use crate::literal::LitVal;
 use crate::multiplicity::MultiplicityLike;
 use crate::resolve::{PatVar, RMult};
@@ -394,6 +395,16 @@ pub struct MatchPool<Cfg: EGraphConfig> {
     /// because it is the only per-query state `run_join` already receives; see
     /// [`OP_FILTER_POLICY`] for why it is not read per join.
     op_filter_policy: OpFilterPolicy,
+    /// The first guard this query found to be undefined on an assignment it
+    /// reached, if any. On the pool for the same reason as `op_filter_policy`:
+    /// it is per-query state and the pool is the one channel every step already
+    /// holds, so recording a fault costs the matcher no extra parameter and no
+    /// `Result` threaded through its continuations.
+    ///
+    /// Only the first is kept: any one of them ends the run, and a rule that is
+    /// partial on one assignment is usually partial on many, so the rest would
+    /// be noise.
+    guard_fault: Option<EvalError>,
 }
 
 impl<Cfg: EGraphConfig> Default for MatchPool<Cfg> {
@@ -410,6 +421,7 @@ impl<Cfg: EGraphConfig> MatchPool<Cfg> {
             mset_bufs: Vec::new(),
             steps: 0,
             op_filter_policy: OpFilterPolicy::Adaptive,
+            guard_fault: None,
         }
     }
 
@@ -417,6 +429,20 @@ impl<Cfg: EGraphConfig> MatchPool<Cfg> {
     /// allocation warm.
     pub fn reshape(&mut self, shape: &crate::resolve::MatchShape) {
         self.set.reshape(shape);
+    }
+
+    /// The guard fault this query hit, if any. `None` means every guard the
+    /// matcher evaluated was defined on the assignment it saw — not that the
+    /// rule's guards are total.
+    pub fn guard_fault(&self) -> Option<&EvalError> {
+        self.guard_fault.as_ref()
+    }
+
+    /// Record a guard fault, keeping the first.
+    fn record_guard_fault(&mut self, e: EvalError) {
+        if self.guard_fault.is_none() {
+            self.guard_fault = Some(e);
+        }
     }
 
     /// One stored match, by row.
@@ -879,6 +905,7 @@ pub fn run_query_into<Cfg, L, S: Copy, const TRACK: bool, const PROOFS: bool>(
     pool.reshape(&plan.shape);
     pool.steps = 0;
     pool.op_filter_policy = op_filter_policy();
+    pool.guard_fault = None;
     let mut env = Match::new(&plan.shape);
     let exec = Exec::<Cfg, L, S>::static_plan(&plan.steps);
     run_step(&exec, 0, eg, index, globals, &mut env, pool);
@@ -911,6 +938,7 @@ pub fn run_query_scheduled_into<Cfg, L, S: Copy, const TRACK: bool, const PROOFS
     pool.reshape(&rq.shape);
     pool.steps = 0;
     pool.op_filter_policy = op_filter_policy();
+    pool.guard_fault = None;
     let mut env = Match::new(&rq.shape);
     let adaptive = Adaptive::new(rq);
     let exec = Exec::adaptive(&adaptive);
@@ -1487,8 +1515,14 @@ fn run_step<Cfg, L, S: Copy, const TRACK: bool, const PROOFS: bool>(
             }
         }
         Step::CheckPred { guard } => {
-            if eval_guard(guard, eg, env) {
-                run_step(exec, step_idx + 1, eg, index, globals, env, results);
+            // A fault stops this branch rather than continuing as if the guard
+            // were false: the run is going to be reported as an error, and
+            // extending an assignment whose guard has no value would be
+            // deriving from a constraint nobody checked.
+            match eval_guard(guard, eg, env) {
+                Ok(true) => run_step(exec, step_idx + 1, eg, index, globals, env, results),
+                Ok(false) => {}
+                Err(e) => results.record_guard_fault(e),
             }
         }
     }
@@ -1503,25 +1537,31 @@ const GUARD_ARGS: usize = 2;
 /// The values come from the match's literal slots, which the guard's `deps` guarantee
 /// are filled: the scheduler emits the check only after every `LitBind` atom feeding it
 /// has run.
+///
+/// `Err` is a guard that is *undefined* on this assignment — say `(i64::< (i64::/ 1 k) 3)`
+/// reached with `k` bound to 0. That is not the same as the guard being false, and it is
+/// deliberately not treated as one: silently skipping the match would hide a partial rule
+/// and make the result depend on which assignments the matcher happened to enumerate. The
+/// caller records the fault, stops extending this match, and the driver reports it.
 fn eval_guard<Cfg, L, const TRACK: bool, const PROOFS: bool>(
     guard: &crate::resolve::PredGuard<Cfg::O, L>,
     eg: &EGraph<Cfg, L, TRACK, PROOFS>,
     env: &Match<Cfg>,
-) -> bool
+) -> Result<bool, EvalError>
 where
     Cfg: EGraphConfig,
     L: LitVal,
     MSetCanon: VarCanon<Cfg::G, Cfg::C>,
 {
-    let v = eval_pred_expr(&guard.expr, eg, env);
-    (guard.truthy)(&v)
+    let v = eval_pred_expr(&guard.expr, eg, env)?;
+    Ok((guard.truthy)(&v))
 }
 
 fn eval_pred_expr<Cfg, L, const TRACK: bool, const PROOFS: bool>(
     expr: &crate::resolve::RPredExpr<Cfg::O, L>,
     eg: &EGraph<Cfg, L, TRACK, PROOFS>,
     env: &Match<Cfg>,
-) -> L
+) -> Result<L, EvalError>
 where
     Cfg: EGraphConfig,
     L: LitVal,
@@ -1529,13 +1569,17 @@ where
 {
     use crate::resolve::RPredExpr;
     match expr {
-        RPredExpr::Val(v) => eg.lits().get(env.get_lit_val(*v)).clone(),
-        RPredExpr::Const(l) => l.clone(),
-        RPredExpr::App { eval, args, .. } => {
-            let vals: SmallVec<[L; GUARD_ARGS]> =
-                args.iter().map(|a| eval_pred_expr(a, eg, env)).collect();
+        RPredExpr::Val(v) => Ok(eg.lits().get(env.get_lit_val(*v)).clone()),
+        RPredExpr::Const(l) => Ok(l.clone()),
+        RPredExpr::App {
+            eval, name, args, ..
+        } => {
+            let mut vals: SmallVec<[L; GUARD_ARGS]> = SmallVec::new();
+            for a in args {
+                vals.push(eval_pred_expr(a, eg, env)?);
+            }
             let refs: SmallVec<[&L; GUARD_ARGS]> = vals.iter().collect();
-            eval(&refs)
+            eval(&refs).ok_or_else(|| EvalError::new(name, &refs, EvalSite::Guard))
         }
     }
 }
@@ -2439,6 +2483,10 @@ pub struct MatchIterator<'a, Cfg: EGraphConfig, L: LitVal, S: Copy, const T: boo
     /// Next plan step to enter (usize::MAX = must backtrack after yield).
     cursor: usize,
     done: bool,
+    /// The first guard found undefined on an assignment this iterator reached.
+    /// The pull engine has no result pool to hang it on, so it lives here; see
+    /// [`MatchPool::guard_fault`] for why one fault is enough.
+    guard_fault: Option<EvalError>,
 }
 
 impl<'a, Cfg, L, S: Copy, const T: bool, const P: bool> MatchIterator<'a, Cfg, L, S, T, P>
@@ -2462,11 +2510,19 @@ where
             frames: Vec::new(),
             cursor: 0,
             done: false,
+            guard_fault: None,
         }
     }
 
     pub fn env(&self) -> &Match<Cfg> {
         &self.env
+    }
+
+    /// The guard fault this iteration hit, if any. Read it after the iteration
+    /// finishes: a fault does not stop enumeration, it only drops the branch it
+    /// was found on.
+    pub fn guard_fault(&self) -> Option<&EvalError> {
+        self.guard_fault.as_ref()
     }
 
     /// Composable iterator that clones each match on yield.
@@ -2653,14 +2709,21 @@ where
                     Enter::Failed
                 }
             }
-            Step::CheckPred { guard } => {
-                if eval_guard(guard, self.eg, &self.env) {
+            Step::CheckPred { guard } => match eval_guard(guard, self.eg, &self.env) {
+                Ok(true) => {
                     self.cursor += 1;
                     Enter::Advanced
-                } else {
+                }
+                Ok(false) => Enter::Failed,
+                // As in `run_step`: record and abandon the branch, rather than
+                // conflate "undefined here" with "false here".
+                Err(e) => {
+                    if self.guard_fault.is_none() {
+                        self.guard_fault = Some(e);
+                    }
                     Enter::Failed
                 }
-            }
+            },
         }
     }
 

--- a/egraph/src/interpret.rs
+++ b/egraph/src/interpret.rs
@@ -544,6 +544,7 @@ where
                 root_vid,
                 subsume,
                 ruleset,
+                span,
             } => {
                 let name = format!("rewrite_{}", self.eg.rules().len());
                 let rule_id = self.eg.register_rule(&name, "", "");
@@ -562,6 +563,7 @@ where
                     rhs_locals: *rhs_locals,
                     actions,
                     ruleset: *ruleset,
+                    span: *span,
                 };
                 Self::check_rule_mults(&name, &rule)?;
                 self.rules.push(rule);
@@ -571,6 +573,7 @@ where
                 rhs_locals,
                 actions,
                 ruleset,
+                span,
             } => {
                 let name = format!("rule_{}", self.eg.rules().len());
                 let rule_id = self.eg.register_rule(&name, "", "");
@@ -584,6 +587,7 @@ where
                     rhs_locals: *rhs_locals,
                     actions: compiled,
                     ruleset: *ruleset,
+                    span: *span,
                 };
                 Self::check_rule_mults(&name, &rule)?;
                 self.rules.push(rule);

--- a/egraph/src/interpret.rs
+++ b/egraph/src/interpret.rs
@@ -32,11 +32,26 @@ pub enum InterpError {
     ExtractFailed(crate::extract::ExtractError),
     /// `(pop)` without matching `(push)`.
     PopWithoutPush,
+    /// A rule applied a partial primitive operation outside its domain while a
+    /// `(run …)` or `(check …)` was saturating: division by zero, an overflow
+    /// under checked arithmetic, a multiplicity too wide for the configuration.
+    ///
+    /// Separate from `CompileError` because nothing about the rule is wrong:
+    /// it sortchecks, and the operands only exist once it matches. The engine
+    /// cannot pick a value on the program's behalf, so the run stops here and
+    /// the driver exits nonzero.
+    EvalFailed(crate::lit_model::EvalError),
 }
 
 impl From<crate::resolve::ResolveError> for InterpError {
     fn from(e: crate::resolve::ResolveError) -> Self {
         InterpError::CompileError(e)
+    }
+}
+
+impl From<crate::lit_model::EvalError> for InterpError {
+    fn from(e: crate::lit_model::EvalError) -> Self {
+        InterpError::EvalFailed(e)
     }
 }
 
@@ -50,6 +65,7 @@ impl std::fmt::Display for InterpError {
             InterpError::CheckFailed(s) => write!(f, "check failed: {s}"),
             InterpError::ExtractFailed(e) => write!(f, "extract failed: {e}"),
             InterpError::PopWithoutPush => write!(f, "pop without matching push"),
+            InterpError::EvalFailed(e) => write!(f, "{e}"),
         }
     }
 }
@@ -288,7 +304,7 @@ where
     /// this driver's operational joint fixpoint without joining the pair. It is
     /// not a semantic non-derivability theorem: matching is over materialized
     /// nodes, and AC scalar-subterm matching remains incomplete.
-    fn lazy_ac_decide(&mut self, a: Cfg::G, b: Cfg::G) -> (bool, bool) {
+    fn lazy_ac_decide(&mut self, a: Cfg::G, b: Cfg::G) -> Result<(bool, bool), InterpError> {
         self.lazy_txn_open();
         self.eg.set_cc_goal(Some((a, b)));
         self.eg.rebuild();
@@ -326,11 +342,21 @@ where
                     &mut self.index_scratch,
                 ),
             };
+            // The completion goal is cleared on the fault path too: it is state
+            // on the e-graph, and a caller that reports the error and keeps the
+            // interpreter alive must not inherit a goal from a run that ended.
+            let result = match result {
+                Ok(r) => r,
+                Err(e) => {
+                    self.eg.set_cc_goal(None);
+                    return Err(e.into());
+                }
+            };
             equal = self.eg.find(a) == self.eg.find(b);
             inconclusive = !equal && (aborted(&self.eg) || !result.saturated);
         }
         self.eg.set_cc_goal(None);
-        (equal, inconclusive)
+        Ok((equal, inconclusive))
     }
 
     /// Enable/disable the runtime reduced-basis invariant checks (default off; see
@@ -446,7 +472,7 @@ where
                 self.eg.rebuild();
                 if self.eg.find(a_id) != self.eg.find(b_id) {
                     if self.ac_mode == AcMode::Lazy {
-                        match self.lazy_ac_decide(a_id, b_id) {
+                        match self.lazy_ac_decide(a_id, b_id)? {
                             (true, _) => return Ok(()),
                             (false, aborted) => {
                                 return Err(InterpError::CheckFailed(if aborted {
@@ -481,7 +507,7 @@ where
                 // implemented operational fixpoint without a join is the command's
                 // acceptance criterion, not a semantic non-disequality theorem.
                 if self.ac_mode == AcMode::Lazy {
-                    match self.lazy_ac_decide(a_id, b_id) {
+                    match self.lazy_ac_decide(a_id, b_id)? {
                         (true, _) => {
                             return Err(InterpError::CheckFailed(
                                 "terms are equal (derived by lazy AC completion)".into(),
@@ -611,8 +637,11 @@ where
                         )
                     }
                 };
+                // The elapsed time is recorded before the fault is propagated:
+                // the run did take that long, and `(print-stats)` after a caught
+                // error should not read a stale duration from an earlier run.
                 self.last_run_time = Some(t0.elapsed());
-                self.last_sat = Some(result);
+                self.last_sat = Some(result?);
             }
             CCommand::PrintSize(op) => {
                 let counts = self.eg.op_node_counts();

--- a/egraph/src/interpret.rs
+++ b/egraph/src/interpret.rs
@@ -825,14 +825,78 @@ where
                 (id, *sort)
             }
             CTerm::App { op, sort, children } => {
-                let child_ids: Vec<Cfg::G> =
-                    children.iter().map(|c| self.build_cterm(c).0).collect();
+                // Associativity on the term as *written*, before the child ids exist.
+                //
+                // For an A-only operator, `(F (F a b) c)` and `(F a b c)` are the same term,
+                // and this is the only place that fact is visible: here `children` is the
+                // syntax tree, so a nested same-op argument is a nested *application*.
+                // `EGraph::add` cannot make this decision, because by then a child is a
+                // `Cfg::G` and a nested application is indistinguishable from a class id that
+                // merely happens to be a `Seq` node — an RHS rest binding hands `add` exactly
+                // such ids, and splicing those rewrites uphill (`seq(a,b)` to
+                // `seq(unit,a,b)` and again every round, `a_singleton_collapse.egg`).
+                //
+                // The class-level test in `flatten_seq_children` still runs after this and is
+                // still needed: it flattens a child that came back from `add` already
+                // flattenable. What this adds is order independence for the written nesting,
+                // which that test cannot give — a class stops being a *pure* sequence as soon
+                // as anything is unioned into it, so `(union (F a b) blob)` before
+                // `(F (F a b) c)` used to store the nested spelling and never rejoin
+                // `(F a b c)`, while the two statements the other way round flattened it.
+                //
+                // A `Global` argument is deliberately not spliced: a name is opaque here, and
+                // resolving it would read the graph again, which is what this avoids.
+                let dir = match self.eg.ops().info(*op).kind {
+                    crate::registry::OpKind::A { dir, .. } => Some(dir),
+                    _ => None,
+                };
+                let child_ids: Vec<Cfg::G> = match dir {
+                    None => children.iter().map(|c| self.build_cterm(c).0).collect(),
+                    Some(dir) => {
+                        let mut ids = Vec::with_capacity(children.len());
+                        self.push_seq_args(children, *op, dir, &mut ids);
+                        ids
+                    }
+                };
                 let id = self.eg.add(*op, &child_ids);
                 (id, *sort)
             }
             CTerm::Global(name, sort) => {
                 let (_, _, id) = self.globals.get(name).expect("global not found at runtime");
                 (self.eg.find(id), *sort)
+            }
+        }
+    }
+
+    /// Build the argument list of an A-only application, splicing a nested same-`op`
+    /// application on the declared spine instead of building it as one child.
+    ///
+    /// Recursive, so `(F (F (F a b) c) d)` yields `[a, b, c, d)]` in one pass. See the note in
+    /// [`build_cterm`](Self::build_cterm) for why this belongs here and not in `EGraph::add`.
+    fn push_seq_args(
+        &mut self,
+        children: &[CTerm<Cfg::O, Cfg::S, L>],
+        op: Cfg::O,
+        dir: crate::registry::AssocDir,
+        out: &mut Vec<Cfg::G>,
+    ) {
+        use crate::registry::AssocDir;
+        let last = children.len().saturating_sub(1);
+        for (i, c) in children.iter().enumerate() {
+            // Off the declared spine a nested application is explicit grouping that the
+            // operator does not flatten: for a left fold `a - (b - c)` is not `a - b - c`.
+            let on_spine = match dir {
+                AssocDir::Both => true,
+                AssocDir::Left => i == 0,
+                AssocDir::Right => i == last,
+            };
+            match c {
+                CTerm::App {
+                    op: inner_op,
+                    children: inner,
+                    ..
+                } if on_spine && *inner_op == op => self.push_seq_args(inner, op, dir, out),
+                _ => out.push(self.build_cterm(c).0),
             }
         }
     }

--- a/egraph/src/lit_model.rs
+++ b/egraph/src/lit_model.rs
@@ -6,6 +6,8 @@
 //! Clients implement `LitModel` to plug their literal value type into the
 //! e-graph, parser, and rewriting engine.
 
+use std::fmt;
+
 use crate::literal::LitVal;
 
 /// Descriptor for a literal sort (e.g. "Int" backed by `IBig`).
@@ -32,7 +34,17 @@ pub struct LitOpDesc<V> {
     /// Return literal sort name.
     pub ret_sort: &'static str,
     /// Evaluate the operation on concrete values.
-    pub eval: fn(&[&V]) -> V,
+    ///
+    /// `None` means the operation is *partial* and these arguments are outside
+    /// its domain: an integer division by zero, a checked-arithmetic overflow,
+    /// an exponent too large for the primitive's exponent type. The engine
+    /// turns that into an [`EvalError`] and stops the run; see there for why
+    /// this is a `None` rather than a panic.
+    ///
+    /// It is not the channel for a sort mismatch. Argument sorts are settled by
+    /// sortcheck against `arg_sorts` before a rule is installed, so an
+    /// implementation may treat an unexpected variant as unreachable.
+    pub eval: fn(&[&V]) -> Option<V>,
 }
 
 impl<V> Clone for LitOpDesc<V> {
@@ -41,6 +53,95 @@ impl<V> Clone for LitOpDesc<V> {
     }
 }
 impl<V> Copy for LitOpDesc<V> {}
+
+/// Where in a rule a partial operation was applied outside its domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvalSite {
+    /// A primitive application in a right-hand side.
+    Rhs,
+    /// A predicate guard on a left-hand side.
+    Guard,
+    /// A multiplicity expression on a right-hand side.
+    Multiplicity,
+}
+
+impl fmt::Display for EvalSite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            EvalSite::Rhs => "the right-hand side",
+            EvalSite::Guard => "a guard",
+            EvalSite::Multiplicity => "a multiplicity expression",
+        })
+    }
+}
+
+/// A partial operation applied outside its domain while a rule ran.
+///
+/// This is a *program* error, not an engine invariant violation. The rule is
+/// well sorted and the match is real; the arguments only became available when
+/// the rule fired, and on these particular ones the operation has no value. So
+/// there is nothing for the engine to repair and no term it could sensibly
+/// build, and the honest response is to stop and say which operation on which
+/// operands failed.
+///
+/// It is reported rather than panicked for the same reason: a panic aborts the
+/// process and leaves the caller unable to tell a bad `.egg` program from a bug
+/// in the engine. An [`EvalError`] travels out through `apply` and `saturate`
+/// to the interpreter, which prints it and exits nonzero.
+///
+/// Sort mismatches are deliberately *not* represented here — see
+/// [`LitOpDesc::eval`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvalError {
+    /// Surface name of the operation, e.g. `"i64::/"` or `"u64::-"`.
+    pub op: &'static str,
+    /// The operands it was applied to, already formatted: the error outlives
+    /// the borrowed values, and the value type is only `Display` here.
+    pub args: Vec<String>,
+    /// Which part of the rule was under evaluation.
+    pub site: EvalSite,
+    /// The rule's name, filled in at the boundary that knows it. The
+    /// evaluators see only the operation, so they leave this `None`.
+    pub rule: Option<String>,
+}
+
+impl EvalError {
+    /// Record a fault at `site`, formatting the operands for the diagnostic.
+    pub fn new<V: fmt::Display>(op: &'static str, args: &[&V], site: EvalSite) -> Self {
+        Self {
+            op,
+            args: args.iter().map(|a| a.to_string()).collect(),
+            site,
+            rule: None,
+        }
+    }
+
+    /// Attribute the fault to a rule. Keeps an existing attribution, so the
+    /// innermost frame that knows a name wins.
+    pub fn in_rule(mut self, name: &str) -> Self {
+        if self.rule.is_none() {
+            self.rule = Some(name.to_owned());
+        }
+        self
+    }
+}
+
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(rule) = &self.rule {
+            write!(f, "rule '{rule}': ")?;
+        }
+        write!(
+            f,
+            "{} in {} is undefined on ({})",
+            self.op,
+            self.site,
+            self.args.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for EvalError {}
 
 /// Client-defined literal value model.
 ///

--- a/egraph/src/lit_model.rs
+++ b/egraph/src/lit_model.rs
@@ -103,6 +103,10 @@ pub struct EvalError {
     /// The rule's name, filled in at the boundary that knows it. The
     /// evaluators see only the operation, so they leave this `None`.
     pub rule: Option<String>,
+    /// Source span of the rule that was applying, filled in with the name. Byte offsets,
+    /// because that is what the parser records and what this type can hold without borrowing
+    /// the program text; [`render`](Self::render) turns them into a line and column.
+    pub span: crate::ast::Span,
 }
 
 impl EvalError {
@@ -113,6 +117,7 @@ impl EvalError {
             args: args.iter().map(|a| a.to_string()).collect(),
             site,
             rule: None,
+            span: crate::ast::Span::Dummy,
         }
     }
 
@@ -123,6 +128,38 @@ impl EvalError {
             self.rule = Some(name.to_owned());
         }
         self
+    }
+
+    /// Attach the applying rule's source span. Keeps an existing span, matching
+    /// [`in_rule`](Self::in_rule): the innermost frame that knows a location wins.
+    pub fn at(mut self, span: crate::ast::Span) -> Self {
+        if matches!(self.span, crate::ast::Span::Dummy) {
+            self.span = span;
+        }
+        self
+    }
+
+    /// The message with the rule's **line and column**, which `Display` cannot report because
+    /// it does not have the program text. Falls back to `Display` when the span is unresolvable
+    /// (a rule built through the API rather than parsed), so a caller can always use this.
+    pub fn render(&self, src: &str) -> String {
+        match self.span.render_in(src) {
+            Some(at) => match &self.rule {
+                Some(rule) => format!(
+                    "rule '{rule}' at {at}: {} in {} is undefined on ({})",
+                    self.op,
+                    self.site,
+                    self.args.join(", ")
+                ),
+                None => format!(
+                    "at {at}: {} in {} is undefined on ({})",
+                    self.op,
+                    self.site,
+                    self.args.join(", ")
+                ),
+            },
+            None => self.to_string(),
+        }
     }
 }
 

--- a/egraph/src/literal.rs
+++ b/egraph/src/literal.rs
@@ -262,7 +262,7 @@ macro_rules! nira_int_binop {
     ($name:expr, $op:tt) => {
         LitOpDesc { name: $name, arg_sorts: &["IBig", "IBig"], ret_sort: "IBig",
             eval: |args| match (args[0], args[1]) {
-                (NiraLitVal::Int(a), NiraLitVal::Int(b)) => NiraLitVal::Int(a $op b),
+                (NiraLitVal::Int(a), NiraLitVal::Int(b)) => Some(NiraLitVal::Int(a $op b)),
                 _ => panic!("type error"),
             },
         }
@@ -273,7 +273,7 @@ macro_rules! nira_rat_binop {
     ($name:expr, $op:tt) => {
         LitOpDesc { name: $name, arg_sorts: &["RBig", "RBig"], ret_sort: "RBig",
             eval: |args| match (args[0], args[1]) {
-                (NiraLitVal::Rat(a), NiraLitVal::Rat(b)) => NiraLitVal::Rat(a $op b),
+                (NiraLitVal::Rat(a), NiraLitVal::Rat(b)) => Some(NiraLitVal::Rat(a $op b)),
                 _ => panic!("type error"),
             },
         }
@@ -287,13 +287,29 @@ const NIRA_OPS: &[LitOpDesc<NiraLitVal>] = &[
     nira_rat_binop!("r+", +),
     nira_rat_binop!("r-", -),
     nira_rat_binop!("r*", *),
-    nira_rat_binop!("r/", /),
+    // Not `nira_rat_binop!`: rational division is the one partial operation in
+    // this model, and dividing by zero has no value rather than a value the
+    // engine could build.
+    LitOpDesc {
+        name: "r/",
+        arg_sorts: &["RBig", "RBig"],
+        ret_sort: "RBig",
+        eval: |args| match (args[0], args[1]) {
+            (NiraLitVal::Rat(a), NiraLitVal::Rat(b)) => {
+                if b.is_zero() {
+                    return None;
+                }
+                Some(NiraLitVal::Rat(a / b))
+            }
+            _ => panic!("type error"),
+        },
+    },
     LitOpDesc {
         name: "<",
         arg_sorts: &["IBig", "IBig"],
         ret_sort: "bool",
         eval: |args| match (args[0], args[1]) {
-            (NiraLitVal::Int(a), NiraLitVal::Int(b)) => NiraLitVal::Bool(a < b),
+            (NiraLitVal::Int(a), NiraLitVal::Int(b)) => Some(NiraLitVal::Bool(a < b)),
             _ => panic!("type error"),
         },
     },
@@ -302,7 +318,7 @@ const NIRA_OPS: &[LitOpDesc<NiraLitVal>] = &[
         arg_sorts: &["IBig", "IBig"],
         ret_sort: "bool",
         eval: |args| match (args[0], args[1]) {
-            (NiraLitVal::Int(a), NiraLitVal::Int(b)) => NiraLitVal::Bool(a <= b),
+            (NiraLitVal::Int(a), NiraLitVal::Int(b)) => Some(NiraLitVal::Bool(a <= b)),
             _ => panic!("type error"),
         },
     },
@@ -311,7 +327,7 @@ const NIRA_OPS: &[LitOpDesc<NiraLitVal>] = &[
         arg_sorts: &["IBig", "IBig"],
         ret_sort: "bool",
         eval: |args| match (args[0], args[1]) {
-            (NiraLitVal::Int(a), NiraLitVal::Int(b)) => NiraLitVal::Bool(a != b),
+            (NiraLitVal::Int(a), NiraLitVal::Int(b)) => Some(NiraLitVal::Bool(a != b)),
             _ => panic!("type error"),
         },
     },
@@ -320,7 +336,7 @@ const NIRA_OPS: &[LitOpDesc<NiraLitVal>] = &[
         arg_sorts: &["bool", "bool"],
         ret_sort: "bool",
         eval: |args| match (args[0], args[1]) {
-            (NiraLitVal::Bool(a), NiraLitVal::Bool(b)) => NiraLitVal::Bool(*a && *b),
+            (NiraLitVal::Bool(a), NiraLitVal::Bool(b)) => Some(NiraLitVal::Bool(*a && *b)),
             _ => panic!("type error"),
         },
     },
@@ -329,7 +345,7 @@ const NIRA_OPS: &[LitOpDesc<NiraLitVal>] = &[
         arg_sorts: &["bool", "bool"],
         ret_sort: "bool",
         eval: |args| match (args[0], args[1]) {
-            (NiraLitVal::Bool(a), NiraLitVal::Bool(b)) => NiraLitVal::Bool(*a || *b),
+            (NiraLitVal::Bool(a), NiraLitVal::Bool(b)) => Some(NiraLitVal::Bool(*a || *b)),
             _ => panic!("type error"),
         },
     },
@@ -338,7 +354,7 @@ const NIRA_OPS: &[LitOpDesc<NiraLitVal>] = &[
         arg_sorts: &["bool"],
         ret_sort: "bool",
         eval: |args| match args[0] {
-            NiraLitVal::Bool(a) => NiraLitVal::Bool(!a),
+            NiraLitVal::Bool(a) => Some(NiraLitVal::Bool(!a)),
             _ => panic!("type error"),
         },
     },
@@ -454,15 +470,30 @@ mod tests {
         let a = NiraLitVal::Int(BigInt::from(3));
         let b = NiraLitVal::Int(BigInt::from(7));
         let result = (plus.eval)(&[&a, &b]);
-        assert_eq!(result, NiraLitVal::Int(BigInt::from(10)));
+        assert_eq!(result, Some(NiraLitVal::Int(BigInt::from(10))));
 
         let lt = m.find_op("<").unwrap();
         let result = (lt.eval)(&[&a, &b]);
-        assert_eq!(result, NiraLitVal::Bool(true));
+        assert_eq!(result, Some(NiraLitVal::Bool(true)));
 
         let not = m.find_op("not").unwrap();
         let t = NiraLitVal::Bool(true);
-        assert_eq!((not.eval)(&[&t]), NiraLitVal::Bool(false));
+        assert_eq!((not.eval)(&[&t]), Some(NiraLitVal::Bool(false)));
+    }
+
+    /// The one partial operation in this model: `r/` has no value at a zero
+    /// divisor, and says so instead of panicking inside `BigRational`.
+    #[test]
+    fn nira_rational_division_by_zero_is_undefined() {
+        let m = NiraModel;
+        let div = m.find_op("r/").unwrap();
+        let one = NiraLitVal::Rat(BigRational::from_integer(BigInt::from(1)));
+        let zero = NiraLitVal::Rat(BigRational::from_integer(BigInt::from(0)));
+        assert_eq!((div.eval)(&[&one, &zero]), None);
+        assert_eq!(
+            (div.eval)(&[&one, &one]),
+            Some(NiraLitVal::Rat(BigRational::from_integer(BigInt::from(1))))
+        );
     }
 
     #[test]

--- a/egraph/src/main.rs
+++ b/egraph/src/main.rs
@@ -238,12 +238,16 @@ fn main() {
                     &surface_cmds,
                     MachineModel,
                     &opts,
+                    &src,
                 ),
-                LitValChoice::Bignum => {
-                    run::<$Cfg, BignumLit, BignumModel, $proofs>(&surface_cmds, BignumModel, &opts)
-                }
+                LitValChoice::Bignum => run::<$Cfg, BignumLit, BignumModel, $proofs>(
+                    &surface_cmds,
+                    BignumModel,
+                    &opts,
+                    &src,
+                ),
                 LitValChoice::All => {
-                    run::<$Cfg, AllLit, AllModel, $proofs>(&surface_cmds, AllModel, &opts)
+                    run::<$Cfg, AllLit, AllModel, $proofs>(&surface_cmds, AllModel, &opts, &src)
                 }
             }
         };
@@ -282,6 +286,9 @@ fn run<Cfg, L, M, const PROOFS: bool>(
     surface_cmds: &[semi_persistent_egraph::surface_ast::SurfaceCommand],
     model: M,
     opts: &EngineOptions,
+    // The original program text, kept only to turn a diagnostic's byte offsets into a line
+    // and column (`Span::render_in`). Nothing else reads it.
+    src: &str,
 ) where
     Cfg: semi_persistent_egraph::config::EGraphConfig,
     Cfg::O: std::hash::Hash,
@@ -309,12 +316,22 @@ fn run<Cfg, L, M, const PROOFS: bool>(
     ) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("sort error: {e}");
+            // `SortError::render` carries its own `sort error` prefix and reports a line and
+            // column rather than the byte offsets `Display` is limited to.
+            eprintln!("{}", e.render(src));
             process::exit(1);
         }
     };
     if let Err(e) = interp.run_checked(&checked) {
-        eprintln!("error: {e}");
+        // A primitive fault carries the applying rule's span, which only becomes a line and
+        // column here, where the source is still in hand. Every other interpreter error has
+        // no span to add, so it renders through `Display`.
+        match &e {
+            semi_persistent_egraph::interpret::InterpError::EvalFailed(ev) => {
+                eprintln!("error: {}", ev.render(src))
+            }
+            _ => eprintln!("error: {e}"),
+        }
         process::exit(1);
     }
     if let Some(path) = &opts.dump_proofs {

--- a/egraph/src/main.rs
+++ b/egraph/src/main.rs
@@ -16,7 +16,8 @@ struct Cli {
     #[arg(long, default_value = "31", value_parser = parse_id_bits)]
     id_bits: u8,
 
-    /// Push/pop mechanism: "diff" (semi-persistent undo log) or "clone" (deep copy)
+    /// Push/pop mechanism: "diff" (semi-persistent undo log). "clone" (deep copy) is
+    /// reserved and rejected: no such backend exists.
     #[arg(long, default_value = "diff", value_parser = parse_push_pop)]
     push_pop: PushPop,
 
@@ -129,14 +130,23 @@ fn parse_union_by(s: &str) -> Result<semi_persistent_egraph::UnionBy, String> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PushPop {
     Diff,
-    Clone,
 }
 
+/// `clone` is a **reserved** value, not an accepted one. A deep-copy push/pop backend does
+/// not exist: no container implements one, and nothing outside this file reads this flag. It
+/// used to parse and then exit 1 from `main`, which meant `--help` advertised a mode that
+/// could never run. Rejecting it here says so at the point of use, and keeps the name for the
+/// backend if it is built (its value is as a differential oracle: a from-scratch deep copy is
+/// the reference that diff-log `restore` should reproduce).
 fn parse_push_pop(s: &str) -> Result<PushPop, String> {
     match s {
         "diff" => Ok(PushPop::Diff),
-        "clone" => Ok(PushPop::Clone),
-        _ => Err(format!("expected 'diff' or 'clone', got '{s}'")),
+        "clone" => Err(
+            "'clone' is reserved but not implemented: no deep-copy push/pop backend exists. \
+             Use 'diff' (the semi-persistent undo log), which is the default."
+                .to_string(),
+        ),
+        _ => Err(format!("expected 'diff', got '{s}'")),
     }
 }
 fn parse_id_bits(s: &str) -> Result<u8, String> {
@@ -202,11 +212,6 @@ fn main() {
             })
         })
         .collect();
-
-    if cli.push_pop == PushPop::Clone {
-        eprintln!("--push-pop clone is not yet implemented");
-        process::exit(1);
-    }
 
     let choice = choose_litval(&groups);
 

--- a/egraph/src/model.rs
+++ b/egraph/src/model.rs
@@ -94,6 +94,11 @@ pub fn choose_litval(groups: &[TypeGroup]) -> LitValChoice {
 // Op-generation macros (parameterized by enum name)
 // ---------------------------------------------------------------------------
 
+// Every `eval` below returns `Option`: `None` is "this operation has no value on
+// these operands" (see `LitOpDesc::eval`). The `_ => panic!()` arms are a
+// different thing — a sort mismatch that sortcheck already ruled out — and stay
+// panics, because a `None` there would report a user error for an engine bug.
+
 macro_rules! bool_ops {
     ($E:ident) => {
         &[
@@ -102,7 +107,7 @@ macro_rules! bool_ops {
                 arg_sorts: &["bool", "bool"],
                 ret_sort: "bool",
                 eval: |a| match (a[0], a[1]) {
-                    ($E::Bool(x), $E::Bool(y)) => $E::Bool(*x && *y),
+                    ($E::Bool(x), $E::Bool(y)) => Some($E::Bool(*x && *y)),
                     _ => panic!(),
                 },
             },
@@ -111,7 +116,7 @@ macro_rules! bool_ops {
                 arg_sorts: &["bool", "bool"],
                 ret_sort: "bool",
                 eval: |a| match (a[0], a[1]) {
-                    ($E::Bool(x), $E::Bool(y)) => $E::Bool(*x || *y),
+                    ($E::Bool(x), $E::Bool(y)) => Some($E::Bool(*x || *y)),
                     _ => panic!(),
                 },
             },
@@ -120,7 +125,7 @@ macro_rules! bool_ops {
                 arg_sorts: &["bool"],
                 ret_sort: "bool",
                 eval: |a| match a[0] {
-                    $E::Bool(x) => $E::Bool(!x),
+                    $E::Bool(x) => Some($E::Bool(!x)),
                     _ => panic!(),
                 },
             },
@@ -129,13 +134,7 @@ macro_rules! bool_ops {
                 arg_sorts: &["bool", "bool", "bool"],
                 ret_sort: "bool",
                 eval: |a| match a[0] {
-                    $E::Bool(c) => {
-                        if *c {
-                            a[1].clone()
-                        } else {
-                            a[2].clone()
-                        }
-                    }
+                    $E::Bool(c) => Some(if *c { a[1].clone() } else { a[2].clone() }),
                     _ => panic!(),
                 },
             },
@@ -143,6 +142,8 @@ macro_rules! bool_ops {
     };
 }
 
+/// A checked machine-integer operation: the `checked_*` method's `None` — an
+/// overflow, or a division or remainder by zero — is the op's `None`.
 macro_rules! checked_binop {
     ($E:ident,$V:ident,$n:expr,$s:expr,$m:ident) => {
         LitOpDesc {
@@ -150,7 +151,7 @@ macro_rules! checked_binop {
             arg_sorts: &[$s, $s],
             ret_sort: $s,
             eval: |a| match (a[0], a[1]) {
-                ($E::$V(x), $E::$V(y)) => $E::$V(x.$m(*y).expect($n)),
+                ($E::$V(x), $E::$V(y)) => x.$m(*y).map($E::$V),
                 _ => panic!(),
             },
         }
@@ -163,7 +164,7 @@ macro_rules! wrapping_binop {
             arg_sorts: &[$s, $s],
             ret_sort: $s,
             eval: |a| match (a[0], a[1]) {
-                ($E::$V(x), $E::$V(y)) => $E::$V(x.$m(*y)),
+                ($E::$V(x), $E::$V(y)) => Some($E::$V(x.$m(*y))),
                 _ => panic!(),
             },
         }
@@ -176,7 +177,7 @@ macro_rules! saturating_binop {
             arg_sorts: &[$s, $s],
             ret_sort: $s,
             eval: |a| match (a[0], a[1]) {
-                ($E::$V(x), $E::$V(y)) => $E::$V(x.$m(*y)),
+                ($E::$V(x), $E::$V(y)) => Some($E::$V(x.$m(*y))),
                 _ => panic!(),
             },
         }
@@ -184,7 +185,7 @@ macro_rules! saturating_binop {
 }
 macro_rules! cmp_op { ($E:ident,$V:ident,$n:expr,$s:expr,$op:tt) => {
     LitOpDesc { name: $n, arg_sorts: &[$s,$s], ret_sort: "bool",
-        eval: |a| match (a[0],a[1]) { ($E::$V(x),$E::$V(y)) => $E::Bool(x $op y), _=>panic!() } }
+        eval: |a| match (a[0],a[1]) { ($E::$V(x),$E::$V(y)) => Some($E::Bool(x $op y)), _=>panic!() } }
 };}
 macro_rules! if_op {
     ($E:ident,$n:expr,$s:expr) => {
@@ -193,13 +194,7 @@ macro_rules! if_op {
             arg_sorts: &["bool", $s, $s],
             ret_sort: $s,
             eval: |a| match a[0] {
-                $E::Bool(c) => {
-                    if *c {
-                        a[1].clone()
-                    } else {
-                        a[2].clone()
-                    }
-                }
+                $E::Bool(c) => Some(if *c { a[1].clone() } else { a[2].clone() }),
                 _ => panic!(),
             },
         }
@@ -212,7 +207,7 @@ macro_rules! min_op {
             arg_sorts: &[$s, $s],
             ret_sort: $s,
             eval: |a| match (a[0], a[1]) {
-                ($E::$V(x), $E::$V(y)) => $E::$V(*x.min(y)),
+                ($E::$V(x), $E::$V(y)) => Some($E::$V(*x.min(y))),
                 _ => panic!(),
             },
         }
@@ -225,7 +220,7 @@ macro_rules! max_op {
             arg_sorts: &[$s, $s],
             ret_sort: $s,
             eval: |a| match (a[0], a[1]) {
-                ($E::$V(x), $E::$V(y)) => $E::$V(*x.max(y)),
+                ($E::$V(x), $E::$V(y)) => Some($E::$V(*x.max(y))),
                 _ => panic!(),
             },
         }
@@ -241,29 +236,32 @@ macro_rules! signed_int_ops { ($E:ident, $V:ident, $s:expr) => { &[
     LitOpDesc { name: concat!($s,"::pow"), arg_sorts: &[$s,$s], ret_sort: $s,
         eval: |a| match (a[0], a[1]) {
             ($E::$V(x), $E::$V(e)) => {
-                let e = u32::try_from(*e).expect(concat!($s,"::pow exponent out of range"));
-                $E::$V(x.checked_pow(e).expect(concat!($s,"::pow overflow")))
+                // `checked_pow` takes a `u32` exponent. An exponent outside
+                // that range is outside the operation's domain, not something
+                // to truncate: `try_from` decides it, never an `as` cast.
+                let e = u32::try_from(*e).ok()?;
+                x.checked_pow(e).map($E::$V)
             }
             _ => panic!(),
         } },
     LitOpDesc { name: concat!($s,"::neg"), arg_sorts: &[$s], ret_sort: $s,
-        eval: |a| match a[0] { $E::$V(x) => $E::$V(x.checked_neg().expect(concat!($s,"::neg overflow"))), _=>panic!() } },
+        eval: |a| match a[0] { $E::$V(x) => x.checked_neg().map($E::$V), _=>panic!() } },
     LitOpDesc { name: concat!($s,"::abs"), arg_sorts: &[$s], ret_sort: $s,
-        eval: |a| match a[0] { $E::$V(x) => $E::$V(x.checked_abs().expect(concat!($s,"::abs overflow"))), _=>panic!() } },
+        eval: |a| match a[0] { $E::$V(x) => x.checked_abs().map($E::$V), _=>panic!() } },
     wrapping_binop!($E,$V,concat!($s,"::wrapping_add"),$s,wrapping_add),
     wrapping_binop!($E,$V,concat!($s,"::wrapping_sub"),$s,wrapping_sub),
     wrapping_binop!($E,$V,concat!($s,"::wrapping_mul"),$s,wrapping_mul),
     LitOpDesc { name: concat!($s,"::wrapping_neg"), arg_sorts: &[$s], ret_sort: $s,
-        eval: |a| match a[0] { $E::$V(x) => $E::$V(x.wrapping_neg()), _=>panic!() } },
+        eval: |a| match a[0] { $E::$V(x) => Some($E::$V(x.wrapping_neg())), _=>panic!() } },
     LitOpDesc { name: concat!($s,"::wrapping_abs"), arg_sorts: &[$s], ret_sort: $s,
-        eval: |a| match a[0] { $E::$V(x) => $E::$V(x.wrapping_abs()), _=>panic!() } },
+        eval: |a| match a[0] { $E::$V(x) => Some($E::$V(x.wrapping_abs())), _=>panic!() } },
     saturating_binop!($E,$V,concat!($s,"::saturating_add"),$s,saturating_add),
     saturating_binop!($E,$V,concat!($s,"::saturating_sub"),$s,saturating_sub),
     saturating_binop!($E,$V,concat!($s,"::saturating_mul"),$s,saturating_mul),
     LitOpDesc { name: concat!($s,"::saturating_neg"), arg_sorts: &[$s], ret_sort: $s,
-        eval: |a| match a[0] { $E::$V(x) => $E::$V(x.saturating_neg()), _=>panic!() } },
+        eval: |a| match a[0] { $E::$V(x) => Some($E::$V(x.saturating_neg())), _=>panic!() } },
     LitOpDesc { name: concat!($s,"::saturating_abs"), arg_sorts: &[$s], ret_sort: $s,
-        eval: |a| match a[0] { $E::$V(x) => $E::$V(x.saturating_abs()), _=>panic!() } },
+        eval: |a| match a[0] { $E::$V(x) => Some($E::$V(x.saturating_abs())), _=>panic!() } },
     min_op!($E,$V,concat!($s,"::min"),$s), max_op!($E,$V,concat!($s,"::max"),$s),
     cmp_op!($E,$V,concat!($s,"::<"),$s,<), cmp_op!($E,$V,concat!($s,"::<="),$s,<=),
     cmp_op!($E,$V,concat!($s,"::>"),$s,>), cmp_op!($E,$V,concat!($s,"::>="),$s,>=),
@@ -290,47 +288,56 @@ macro_rules! unsigned_int_ops { ($E:ident, $V:ident, $s:expr) => { &[
     if_op!($E,concat!($s,"::if"),$s),
 ]};}
 
+// IEEE-754 arithmetic is total: division by zero and overflow produce infinities
+// and NaN rather than faulting, so every `f64` op is a `Some`.
 macro_rules! f64_ops { ($E:ident) => { &[
     LitOpDesc { name: "f64::+", arg_sorts: &["f64","f64"], ret_sort: "f64",
-        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => $E::F64(OrderedFloat(*x.as_ref()+*y.as_ref())), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => Some($E::F64(OrderedFloat(*x.as_ref()+*y.as_ref()))), _=>panic!() } },
     LitOpDesc { name: "f64::-", arg_sorts: &["f64","f64"], ret_sort: "f64",
-        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => $E::F64(OrderedFloat(*x.as_ref()-*y.as_ref())), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => Some($E::F64(OrderedFloat(*x.as_ref()-*y.as_ref()))), _=>panic!() } },
     LitOpDesc { name: "f64::*", arg_sorts: &["f64","f64"], ret_sort: "f64",
-        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => $E::F64(OrderedFloat(*x.as_ref()*(*y.as_ref()))), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => Some($E::F64(OrderedFloat(*x.as_ref()*(*y.as_ref())))), _=>panic!() } },
     LitOpDesc { name: "f64::/", arg_sorts: &["f64","f64"], ret_sort: "f64",
-        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => $E::F64(OrderedFloat(*x.as_ref()/(*y.as_ref()))), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => Some($E::F64(OrderedFloat(*x.as_ref()/(*y.as_ref())))), _=>panic!() } },
     LitOpDesc { name: "f64::neg", arg_sorts: &["f64"], ret_sort: "f64",
-        eval: |a| match a[0] { $E::F64(x) => $E::F64(OrderedFloat(-*x.as_ref())), _=>panic!() } },
+        eval: |a| match a[0] { $E::F64(x) => Some($E::F64(OrderedFloat(-*x.as_ref()))), _=>panic!() } },
     LitOpDesc { name: "f64::abs", arg_sorts: &["f64"], ret_sort: "f64",
-        eval: |a| match a[0] { $E::F64(x) => $E::F64(OrderedFloat(x.as_ref().abs())), _=>panic!() } },
+        eval: |a| match a[0] { $E::F64(x) => Some($E::F64(OrderedFloat(x.as_ref().abs()))), _=>panic!() } },
     LitOpDesc { name: "f64::min", arg_sorts: &["f64","f64"], ret_sort: "f64",
-        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => $E::F64(*x.min(y)), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => Some($E::F64(*x.min(y))), _=>panic!() } },
     LitOpDesc { name: "f64::max", arg_sorts: &["f64","f64"], ret_sort: "f64",
-        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => $E::F64(*x.max(y)), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::F64(x),$E::F64(y)) => Some($E::F64(*x.max(y))), _=>panic!() } },
     cmp_op!($E,F64,"f64::<","f64",<), cmp_op!($E,F64,"f64::<=","f64",<=),
     cmp_op!($E,F64,"f64::>","f64",>), cmp_op!($E,F64,"f64::>=","f64",>=),
     cmp_op!($E,F64,"f64::==","f64",==), cmp_op!($E,F64,"f64::!=","f64",!=),
     if_op!($E,"f64::if","f64"),
 ]};}
 
+// The string operations are total. `substr` and `at` keep their documented
+// behaviour of yielding the empty string for a range that is out of bounds or
+// not on a UTF-8 boundary, rather than reporting it: an index is data here, not
+// a partial operation. Their index arithmetic saturates so that a `usize` near
+// the maximum cannot overflow the `+` — the sum is only used to bound a range
+// that `s.get` re-checks anyway.
 macro_rules! string_ops { ($E:ident) => { &[
     LitOpDesc { name: "String::concat", arg_sorts: &["String","String"], ret_sort: "String",
-        eval: |a| match (a[0],a[1]) { ($E::Str(x),$E::Str(y)) => { let mut r=x.clone(); r.push_str(y); $E::Str(r) } _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::Str(x),$E::Str(y)) => { let mut r=x.clone(); r.push_str(y); Some($E::Str(r)) } _=>panic!() } },
     LitOpDesc { name: "String::contains", arg_sorts: &["String","String"], ret_sort: "bool",
-        eval: |a| match (a[0],a[1]) { ($E::Str(x),$E::Str(y)) => $E::Bool(x.contains(y.as_str())), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::Str(x),$E::Str(y)) => Some($E::Bool(x.contains(y.as_str()))), _=>panic!() } },
     LitOpDesc { name: "String::replace", arg_sorts: &["String","String","String"], ret_sort: "String",
-        eval: |a| match (a[0],a[1],a[2]) { ($E::Str(s),$E::Str(f),$E::Str(t)) => $E::Str(s.replacen(f.as_str(),t.as_str(),1)), _=>panic!() } },
+        eval: |a| match (a[0],a[1],a[2]) { ($E::Str(s),$E::Str(f),$E::Str(t)) => Some($E::Str(s.replacen(f.as_str(),t.as_str(),1))), _=>panic!() } },
     cmp_op!($E,Str,"String::==","String",==), cmp_op!($E,Str,"String::!=","String",!=),
     if_op!($E,"String::if","String"),
     LitOpDesc { name: "String::len", arg_sorts: &["String"], ret_sort: "usize",
-        eval: |a| match a[0] { $E::Str(s) => $E::Usize(s.len()), _=>panic!() } },
+        eval: |a| match a[0] { $E::Str(s) => Some($E::Usize(s.len())), _=>panic!() } },
     LitOpDesc { name: "String::substr", arg_sorts: &["String","usize","usize"], ret_sort: "String",
         eval: |a| match (a[0],a[1],a[2]) {
-            ($E::Str(s),$E::Usize(st),$E::Usize(ln)) => $E::Str(s.get(*st..(*st+*ln).min(s.len())).unwrap_or("").to_owned()),
+            ($E::Str(s),$E::Usize(st),$E::Usize(ln)) =>
+                Some($E::Str(s.get(*st..st.saturating_add(*ln).min(s.len())).unwrap_or("").to_owned())),
             _=>panic!(),
         } },
     LitOpDesc { name: "String::at", arg_sorts: &["String","usize"], ret_sort: "String",
-        eval: |a| match (a[0],a[1]) { ($E::Str(s),$E::Usize(i)) => $E::Str(s.get(*i..*i+1).unwrap_or("").to_owned()), _=>panic!() } },
+        eval: |a| match (a[0],a[1]) { ($E::Str(s),$E::Usize(i)) => Some($E::Str(s.get(*i..i.saturating_add(1)).unwrap_or("").to_owned())), _=>panic!() } },
 ]};}
 
 // ---------------------------------------------------------------------------
@@ -360,9 +367,28 @@ fn parse_rbig(s: &str) -> Option<BigRational> {
 // Bignum op macros (use operator overloading, not checked_ methods)
 // ---------------------------------------------------------------------------
 
+/// A *total* arbitrary-precision operation, applied with the plain operator.
+///
+/// Arbitrary precision removes overflow but not partiality, so this macro is
+/// only for the operators that cannot fault on their sort: `+ - *` on `IBig` and
+/// `RBig`, and `+ *` on `UBig`. Division, remainder, and `UBig`'s subtraction
+/// panic in the underlying type and get their own macros below.
 macro_rules! bignum_binop { ($E:ident,$V:ident,$n:expr,$s:expr,$op:tt) => {
     LitOpDesc { name: $n, arg_sorts: &[$s,$s], ret_sort: $s,
-        eval: |a| match (a[0],a[1]) { ($E::$V(x),$E::$V(y)) => $E::$V(x $op y), _=>panic!() } }
+        eval: |a| match (a[0],a[1]) { ($E::$V(x),$E::$V(y)) => Some($E::$V(x $op y)), _=>panic!() } }
+};}
+/// Division or remainder on an arbitrary-precision type: undefined at a zero
+/// divisor, which the underlying type signals by panicking. Tested before the
+/// operator is applied, so the panic is unreachable.
+macro_rules! bignum_divop { ($E:ident,$V:ident,$n:expr,$s:expr,$op:tt) => {
+    LitOpDesc { name: $n, arg_sorts: &[$s,$s], ret_sort: $s,
+        eval: |a| match (a[0],a[1]) {
+            ($E::$V(x),$E::$V(y)) => {
+                if y.is_zero() { return None; }
+                Some($E::$V(x $op y))
+            }
+            _=>panic!(),
+        } }
 };}
 macro_rules! bignum_min {
     ($E:ident,$V:ident,$n:expr,$s:expr) => {
@@ -371,7 +397,7 @@ macro_rules! bignum_min {
             arg_sorts: &[$s, $s],
             ret_sort: $s,
             eval: |a| match (a[0], a[1]) {
-                ($E::$V(x), $E::$V(y)) => $E::$V(x.min(y).clone()),
+                ($E::$V(x), $E::$V(y)) => Some($E::$V(x.min(y).clone())),
                 _ => panic!(),
             },
         }
@@ -384,7 +410,7 @@ macro_rules! bignum_max {
             arg_sorts: &[$s, $s],
             ret_sort: $s,
             eval: |a| match (a[0], a[1]) {
-                ($E::$V(x), $E::$V(y)) => $E::$V(x.max(y).clone()),
+                ($E::$V(x), $E::$V(y)) => Some($E::$V(x.max(y).clone())),
                 _ => panic!(),
             },
         }
@@ -393,12 +419,12 @@ macro_rules! bignum_max {
 
 macro_rules! ibig_ops { ($E:ident) => { &[
     bignum_binop!($E,IBig,"IBig::+","IBig",+), bignum_binop!($E,IBig,"IBig::-","IBig",-),
-    bignum_binop!($E,IBig,"IBig::*","IBig",*), bignum_binop!($E,IBig,"IBig::/","IBig",/),
-    bignum_binop!($E,IBig,"IBig::%","IBig",%),
+    bignum_binop!($E,IBig,"IBig::*","IBig",*), bignum_divop!($E,IBig,"IBig::/","IBig",/),
+    bignum_divop!($E,IBig,"IBig::%","IBig",%),
     LitOpDesc { name: "IBig::neg", arg_sorts: &["IBig"], ret_sort: "IBig",
-        eval: |a| match a[0] { $E::IBig(x) => $E::IBig(-x), _=>panic!() } },
+        eval: |a| match a[0] { $E::IBig(x) => Some($E::IBig(-x)), _=>panic!() } },
     LitOpDesc { name: "IBig::abs", arg_sorts: &["IBig"], ret_sort: "IBig",
-        eval: |a| match a[0] { $E::IBig(x) => $E::IBig(if *x<BigInt::zero() {-x} else {x.clone()}), _=>panic!() } },
+        eval: |a| match a[0] { $E::IBig(x) => Some($E::IBig(if *x<BigInt::zero() {-x} else {x.clone()})), _=>panic!() } },
     bignum_min!($E,IBig,"IBig::min","IBig"), bignum_max!($E,IBig,"IBig::max","IBig"),
     cmp_op!($E,IBig,"IBig::<","IBig",<), cmp_op!($E,IBig,"IBig::<=","IBig",<=),
     cmp_op!($E,IBig,"IBig::>","IBig",>), cmp_op!($E,IBig,"IBig::>=","IBig",>=),
@@ -406,9 +432,17 @@ macro_rules! ibig_ops { ($E:ident) => { &[
     if_op!($E,"IBig::if","IBig"),
 ]};}
 macro_rules! ubig_ops { ($E:ident) => { &[
-    bignum_binop!($E,UBig,"UBig::+","UBig",+), bignum_binop!($E,UBig,"UBig::-","UBig",-),
-    bignum_binop!($E,UBig,"UBig::*","UBig",*), bignum_binop!($E,UBig,"UBig::/","UBig",/),
-    bignum_binop!($E,UBig,"UBig::%","UBig",%),
+    bignum_binop!($E,UBig,"UBig::+","UBig",+),
+    // The one unsigned arbitrary-precision operator that is still partial:
+    // `BigUint`'s `-` panics when the result would be negative, so the order is
+    // the domain condition and is tested first.
+    LitOpDesc { name: "UBig::-", arg_sorts: &["UBig","UBig"], ret_sort: "UBig",
+        eval: |a| match (a[0],a[1]) {
+            ($E::UBig(x),$E::UBig(y)) => if x < y { None } else { Some($E::UBig(x - y)) },
+            _=>panic!(),
+        } },
+    bignum_binop!($E,UBig,"UBig::*","UBig",*), bignum_divop!($E,UBig,"UBig::/","UBig",/),
+    bignum_divop!($E,UBig,"UBig::%","UBig",%),
     bignum_min!($E,UBig,"UBig::min","UBig"), bignum_max!($E,UBig,"UBig::max","UBig"),
     cmp_op!($E,UBig,"UBig::<","UBig",<), cmp_op!($E,UBig,"UBig::<=","UBig",<=),
     cmp_op!($E,UBig,"UBig::>","UBig",>), cmp_op!($E,UBig,"UBig::>=","UBig",>=),
@@ -417,11 +451,11 @@ macro_rules! ubig_ops { ($E:ident) => { &[
 ]};}
 macro_rules! rbig_ops { ($E:ident) => { &[
     bignum_binop!($E,RBig,"RBig::+","RBig",+), bignum_binop!($E,RBig,"RBig::-","RBig",-),
-    bignum_binop!($E,RBig,"RBig::*","RBig",*), bignum_binop!($E,RBig,"RBig::/","RBig",/),
+    bignum_binop!($E,RBig,"RBig::*","RBig",*), bignum_divop!($E,RBig,"RBig::/","RBig",/),
     LitOpDesc { name: "RBig::neg", arg_sorts: &["RBig"], ret_sort: "RBig",
-        eval: |a| match a[0] { $E::RBig(x) => $E::RBig(-x), _=>panic!() } },
+        eval: |a| match a[0] { $E::RBig(x) => Some($E::RBig(-x)), _=>panic!() } },
     LitOpDesc { name: "RBig::abs", arg_sorts: &["RBig"], ret_sort: "RBig",
-        eval: |a| match a[0] { $E::RBig(x) => { let v=x.clone(); $E::RBig(if v<BigRational::zero() {-v} else {v}) } _=>panic!() } },
+        eval: |a| match a[0] { $E::RBig(x) => { let v=x.clone(); Some($E::RBig(if v<BigRational::zero() {-v} else {v})) } _=>panic!() } },
     bignum_min!($E,RBig,"RBig::min","RBig"), bignum_max!($E,RBig,"RBig::max","RBig"),
     cmp_op!($E,RBig,"RBig::<","RBig",<), cmp_op!($E,RBig,"RBig::<=","RBig",<=),
     cmp_op!($E,RBig,"RBig::>","RBig",>), cmp_op!($E,RBig,"RBig::>=","RBig",>=),
@@ -622,7 +656,7 @@ impl LitModel for AllModel {
                 arg_sorts: &["i64"],
                 ret_sort: "RBig",
                 eval: |a| match a[0] {
-                    AllLit::I64(x) => AllLit::RBig(BigRational::from_integer((*x).into())),
+                    AllLit::I64(x) => Some(AllLit::RBig(BigRational::from_integer((*x).into()))),
                     _ => panic!(),
                 },
             });
@@ -632,7 +666,7 @@ impl LitModel for AllModel {
                 ret_sort: "RBig",
                 eval: |a| match (a[0], a[1]) {
                     (AllLit::RBig(x), AllLit::I64(k)) => {
-                        AllLit::RBig(x * BigRational::from_integer((*k).into()))
+                        Some(AllLit::RBig(x * BigRational::from_integer((*k).into())))
                     }
                     _ => panic!(),
                 },
@@ -643,9 +677,16 @@ impl LitModel for AllModel {
                 ret_sort: "RBig",
                 eval: |a| match (a[0], a[1]) {
                     (AllLit::RBig(x), AllLit::I64(e)) => {
-                        let e = i32::try_from(*e).expect("RBig::pow exponent out of range");
-                        assert!(e >= 0, "RBig::pow negative exponent");
-                        AllLit::RBig(x.pow(e))
+                        // `Ratio::pow` takes an `i32`, and a negative exponent
+                        // inverts, which panics at zero. Both are domain
+                        // conditions: an exponent that does not fit `i32`, and a
+                        // negative one, have no value here. Decided by
+                        // `try_from` and a comparison, never by truncation.
+                        let e = i32::try_from(*e).ok()?;
+                        if e < 0 {
+                            return None;
+                        }
+                        Some(AllLit::RBig(x.pow(e)))
                     }
                     _ => panic!(),
                 },

--- a/egraph/src/resolve.rs
+++ b/egraph/src/resolve.rs
@@ -743,6 +743,8 @@ where
     }
 
     link_pred_deps(&mut resolved, &shape)?;
+    check_rest_vars_linear(&resolved, &shape)?;
+    check_nodes_bindable(&resolved, &shape)?;
 
     let mult_intervals = collect_mult_intervals(&resolved, &fq.atoms, &shape)?;
 
@@ -797,6 +799,141 @@ fn link_pred_deps<O, S, L>(atoms: &mut [RAtom<O, S, L>], shape: &MatchShape) -> 
             unreachable!()
         };
         *slot = deps;
+    }
+    Ok(())
+}
+
+/// Reject a rest variable that more than one atom position writes.
+///
+/// A repeated name is the ordinary non-linear case for a node variable: the first
+/// occurrence binds and later ones compile to `CheckEq`/`CheckChildEq`. Rest variables
+/// have no such step. `ExpandA`, `DecomposeAC` and `DecomposeACI` *write* their spans
+/// unconditionally, so a second writer silently overwrites the first and the equality
+/// the repeated name asks for is never checked — the rule then fires on assignments
+/// where the two rests differ, which derives equalities that do not follow. The `Step`
+/// enum has no span comparison at all, so this cannot be checked in the matcher without
+/// a new step; until there is one, the query is rejected here.
+///
+/// `pre` and `suf` of a single variadic atom count as two writers, which is what
+/// rejects `(S ..r x ..r)` as well as a rest shared between two atoms.
+fn check_rest_vars_linear<O, S, L>(atoms: &[RAtom<O, S, L>], shape: &MatchShape) -> R<()> {
+    let mut seqs = vec![0usize; shape.num_seq_vars()];
+    let mut sets = vec![0usize; shape.num_set_vars()];
+    let mut msets = vec![0usize; shape.num_mset_vars()];
+    for a in atoms {
+        match a {
+            RAtom::APrefix { pre, .. } => seqs[pre.idx()] += 1,
+            RAtom::ASuffix { suf, .. } => seqs[suf.idx()] += 1,
+            RAtom::ABoth { pre, suf, .. } => {
+                seqs[pre.idx()] += 1;
+                seqs[suf.idx()] += 1;
+            }
+            RAtom::ACSub { rest, .. } => msets[rest.idx()] += 1,
+            RAtom::ACISub { rest, .. } => sets[rest.idx()] += 1,
+            _ => {}
+        }
+    }
+    // Zip counts against the name tables rather than minting an id back from the index:
+    // the name is all the diagnostic needs, and the counter vectors were sized from the
+    // same `num_*_vars()` the tables have, so the pairing is total in both directions.
+    let offenders = seqs
+        .iter()
+        .zip(&shape.seqs)
+        .chain(sets.iter().zip(&shape.sets))
+        .chain(msets.iter().zip(&shape.msets));
+    for (&count, name) in offenders {
+        if count > 1 {
+            return Err(err(
+                format!(
+                    "rest variable '..{name}' is written {count} times by this rule; a rest \
+                     variable may occur at most once, because the matcher has no step that \
+                     compares two rest spans for equality (use distinct names)"
+                ),
+                Span::Dummy,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reject a query in which some node variable of the match shape can never be bound.
+///
+/// `MatchPool::push` unwraps every node slot of the shape, so a plan that leaves one
+/// unbound aborts the process when the first match is materialized. Every atom kind but
+/// `Eq` and `Pred` binds its own node variable and all its local children when the
+/// scheduler lowers it, so bindability is the closure of those seeds under `Eq`, which
+/// copies a binding in whichever direction is already bound. An `Eq` with neither side in
+/// the closure is lowered by neither scheduler phase — `try_eager_lower` returns `None`
+/// and phase B's argmin skips `Eq` — and the atom is silently dropped, which is the same
+/// shape `Step::BindGlobal` exists to prevent for the global case.
+fn check_nodes_bindable<O, S, L>(atoms: &[RAtom<O, S, L>], shape: &MatchShape) -> R<()> {
+    fn mark(pv: &PatVar, bound: &mut [bool]) {
+        if let PatVar::Local(v) = pv {
+            bound[v.idx()] = true;
+        }
+    }
+    let mut bound = vec![false; shape.num_vars()];
+    for a in atoms {
+        match a {
+            RAtom::Plain { node, children, .. } | RAtom::AExact { node, children, .. } => {
+                bound[node.idx()] = true;
+                for c in children {
+                    mark(c, &mut bound);
+                }
+            }
+            RAtom::APrefix { node, fixed, .. }
+            | RAtom::ASuffix { node, fixed, .. }
+            | RAtom::ABoth { node, fixed, .. } => {
+                bound[node.idx()] = true;
+                for c in fixed {
+                    mark(c, &mut bound);
+                }
+            }
+            RAtom::ACExact { node, elems, .. } | RAtom::ACSub { node, elems, .. } => {
+                bound[node.idx()] = true;
+                for (ev, _) in elems {
+                    mark(ev, &mut bound);
+                }
+            }
+            RAtom::ACIExact { node, elems, .. } | RAtom::ACISub { node, elems, .. } => {
+                bound[node.idx()] = true;
+                for ev in elems {
+                    mark(ev, &mut bound);
+                }
+            }
+            RAtom::Lit { node, .. } | RAtom::LitBind { node, .. } => bound[node.idx()] = true,
+            // `BindGlobal`: the atom is what gives the variable its value.
+            RAtom::EqGlobal(local, _) => bound[local.idx()] = true,
+            // Binds nothing on its own; propagated below.
+            RAtom::Eq(..) | RAtom::Pred { .. } => {}
+        }
+    }
+    // `Eq` copies a binding in either direction, so closing under it can bind a variable
+    // that no scanning atom mentions. Iterate: one `Eq` can feed the next.
+    loop {
+        let mut progress = false;
+        for a in atoms {
+            if let RAtom::Eq(x, y) = a {
+                let (bx, by) = (bound[x.idx()], bound[y.idx()]);
+                if bx != by {
+                    bound[x.idx()] = true;
+                    bound[y.idx()] = true;
+                    progress = true;
+                }
+            }
+        }
+        if !progress {
+            break;
+        }
+    }
+    if let Some((_, name)) = bound.iter().zip(&shape.nodes).find(|(b, _)| !**b) {
+        return Err(err(
+            format!(
+                "variable '{name}' is never bound by this rule: no pattern in it can give the \
+                 variable a value"
+            ),
+            Span::Dummy,
+        ));
     }
     Ok(())
 }

--- a/egraph/src/resolve.rs
+++ b/egraph/src/resolve.rs
@@ -245,7 +245,14 @@ pub enum RPredExpr<O, L> {
     Const(L),
     App {
         op: O,
-        eval: fn(&[&L]) -> L,
+        /// The model's [`crate::lit_model::LitOpDesc::eval`]. `None` from it is
+        /// the guard being undefined on this assignment, not the guard failing;
+        /// the matcher reports it rather than quietly dropping the match.
+        eval: fn(&[&L]) -> Option<L>,
+        /// The operation's surface name, carried so a fault can be attributed
+        /// to it. Only the pointer is otherwise needed, and a pointer cannot be
+        /// turned back into a name.
+        name: &'static str,
         args: Vec<RPredExpr<O, L>>,
     },
 }
@@ -1632,11 +1639,13 @@ where
             for (a, s) in args.iter().zip(arg_sorts) {
                 rargs.push(resolve_pred_expr(a, Some(*s), ops, sorts, model, shape)?);
             }
+            // A primitive op's id is its index into the model's op table: the
+            // registry registers `LitModel::ops()` first and in order.
+            let desc = &model.ops()[op_id.to_usize()];
             Ok(RPredExpr::App {
                 op: op_id,
-                // A primitive op's id is its index into the model's op table: the
-                // registry registers `LitModel::ops()` first and in order.
-                eval: model.ops()[op_id.to_usize()].eval,
+                eval: desc.eval,
+                name: desc.name,
                 args: rargs,
             })
         }

--- a/egraph/src/saturate.rs
+++ b/egraph/src/saturate.rs
@@ -9,7 +9,7 @@ use crate::containers::DenseId;
 use crate::egraph::EGraph;
 use crate::ematch::MatchPool;
 use crate::index::IndexStore;
-use crate::lit_model::LitModel;
+use crate::lit_model::{EvalError, LitModel};
 use crate::literal::LitVal;
 
 /// The goal of a `(run … :until …)`: two already-built class ids and the relation that has
@@ -92,13 +92,18 @@ pub enum SaturationStrategy {
 }
 
 /// Run equality saturation for up to `limit` iterations, over every rule given.
+///
+/// `Err` is a partial primitive operation applied outside its domain by a rule
+/// that fired — see [`EvalError`]. It ends the run at the action that faulted:
+/// the effects already applied stay in the e-graph, and the caller is expected
+/// to report and stop rather than keep saturating.
 pub fn saturate<Cfg, L, M, S, const T: bool, const P: bool>(
     rules: &[PreparedRule<Cfg::O, S, L>],
     eg: &mut EGraph<Cfg, L, T, P>,
     model: &M,
     limit: usize,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> SatResult
+) -> Result<SatResult, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -117,7 +122,7 @@ pub fn saturate_spec<Cfg, L, M, S, const T: bool, const P: bool>(
     model: &M,
     spec: &RunSpec<Cfg::G>,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> SatResult
+) -> Result<SatResult, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -152,7 +157,7 @@ pub fn saturate_spec_in<Cfg, L, M, S, const T: bool, const P: bool>(
     spec: &RunSpec<Cfg::G>,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
     scratch: &mut crate::index::IndexScratch<Cfg>,
-) -> SatResult
+) -> Result<SatResult, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -169,7 +174,7 @@ where
             eg.rebuild();
         }
         if goal_met(spec, eg) {
-            return sat_result(i, false, true, steps_base);
+            return Ok(sat_result(i, false, true, steps_base));
         }
         let index = {
             let _t = crate::phase_timing::Timer::start(crate::phase_timing::FULL);
@@ -183,7 +188,11 @@ where
                 crate::schedule::IndexStats::from_index(&index)
             };
             for rule in rules.iter().filter(|r| r.ruleset == spec.ruleset) {
-                changes += apply_rule_pooled(rule, eg, &index, &stats, model, globals, &mut pool);
+                // A fault gives up the recycled arenas: `?` skips the
+                // `recycle_into` below. That costs one round's arenas on a path
+                // that ends the program, and keeping them would mean either a
+                // guard object or duplicating the recycle on the error path.
+                changes += apply_rule_pooled(rule, eg, &index, &stats, model, globals, &mut pool)?;
             }
         }
         // Before any exit from the loop body: the arenas go back so the next
@@ -192,7 +201,7 @@ where
         crate::phase_timing::count(crate::phase_timing::C_ROUNDS, 1);
         crate::phase_timing::round_line("naive");
         if changes == 0 {
-            return sat_result(i + 1, true, false, steps_base);
+            return Ok(sat_result(i + 1, true, false, steps_base));
         }
     }
     // The budget is spent, but a goal met by the last iteration's work should still be
@@ -203,7 +212,7 @@ where
         eg.rebuild();
     }
     let met = goal_met(spec, eg);
-    sat_result(spec.limit, false, met, steps_base)
+    Ok(sat_result(spec.limit, false, met, steps_base))
 }
 
 /// Does the run's `:until` goal hold? Always false when there is no goal.
@@ -421,7 +430,8 @@ where
 }
 
 /// Schedule one (rule, variant) against `vindex` and apply its actions to
-/// every match. Returns the number of changes applied.
+/// every match. Returns the number of changes applied, or the first
+/// [`EvalError`] a fired action produced.
 /// `pool` is carried across every (rule, variant) in a saturation run so the
 /// match buffers are allocated once and then recycled; see [`MatchPool`].
 fn run_rule_variant<Cfg, L, M, S, const T: bool, const P: bool>(
@@ -432,7 +442,7 @@ fn run_rule_variant<Cfg, L, M, S, const T: bool, const P: bool>(
     model: &M,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
     pool: &mut MatchPool<Cfg>,
-) -> usize
+) -> Result<usize, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -453,12 +463,22 @@ where
     let sampler = crate::index::IndexSampler::new(eg, *vindex);
     let plan = crate::schedule::schedule_with_stats_sampled(&rule.query, stats, &sampler);
     crate::ematch::run_query_scheduled_into(&rule.query, &plan, eg, vindex, globals, pool);
+    // Checked before the actions, for the same reason as in `apply_rule_pooled`:
+    // the matcher dropped the assignment the guard was undefined on, so the
+    // surviving matches are the answers to a query the engine could not fully
+    // evaluate.
+    if let Some(fault) = pool.guard_fault() {
+        return Err(crate::apply::name_fault(fault.clone(), rule, eg));
+    }
     let mut changes = 0;
     for j in 0..pool.len() {
         let row = pool.row(j);
-        changes += crate::apply::apply_rule_actions(rule, &row, eg, model, globals);
+        match crate::apply::apply_rule_actions(rule, &row, eg, model, globals) {
+            Ok(n) => changes += n,
+            Err(e) => return Err(crate::apply::name_fault(e, rule, eg)),
+        }
     }
-    changes
+    Ok(changes)
 }
 
 /// Semi-naive saturation: equivalent to [`saturate`] but, each round after
@@ -475,7 +495,7 @@ pub fn saturate_semi<Cfg, L, M, S, const T: bool, const P: bool>(
     model: &M,
     limit: usize,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> SatResult
+) -> Result<SatResult, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -494,7 +514,7 @@ pub fn saturate_semi_spec<Cfg, L, M, S, const T: bool, const P: bool>(
     model: &M,
     spec: &RunSpec<Cfg::G>,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> SatResult
+) -> Result<SatResult, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -526,7 +546,7 @@ pub fn saturate_semi_spec_in<Cfg, L, M, S, const T: bool, const P: bool>(
     spec: &RunSpec<Cfg::G>,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
     scratch: &mut crate::index::IndexScratch<Cfg>,
-) -> SatResult
+) -> Result<SatResult, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -545,7 +565,7 @@ where
             eg.rebuild();
         }
         if goal_met(spec, eg) {
-            return sat_result(i, false, true, steps_base);
+            return Ok(sat_result(i, false, true, steps_base));
         }
         let full = {
             let _t = crate::phase_timing::Timer::start(crate::phase_timing::FULL);
@@ -577,7 +597,7 @@ where
                 let vindex = VariantIndex::naive(&full);
                 for rule in rules.iter().filter(|r| r.ruleset == spec.ruleset) {
                     changes +=
-                        run_rule_variant(rule, eg, &vindex, &stats, model, globals, &mut pool);
+                        run_rule_variant(rule, eg, &vindex, &stats, model, globals, &mut pool)?;
                 }
             }
             // Rounds ≥ 1: one variant per join atom.
@@ -602,7 +622,7 @@ where
                             model,
                             globals,
                             &mut pool,
-                        );
+                        )?;
                         continue;
                     }
                     for &di in &jatoms {
@@ -613,7 +633,7 @@ where
                         };
                         let vindex = VariantIndex::variant(&full, delta, di);
                         changes +=
-                            run_rule_variant(rule, eg, &vindex, &stats, model, globals, &mut pool);
+                            run_rule_variant(rule, eg, &vindex, &stats, model, globals, &mut pool)?;
                     }
                 }
             }
@@ -630,7 +650,7 @@ where
         crate::phase_timing::round_line(if had_delta { "semi" } else { "semi-r0" });
 
         if changes == 0 {
-            return sat_result(i + 1, true, false, steps_base);
+            return Ok(sat_result(i + 1, true, false, steps_base));
         }
     }
     if spec.until.is_some() {
@@ -638,7 +658,7 @@ where
         eg.rebuild();
     }
     let met = goal_met(spec, eg);
-    sat_result(limit, false, met, steps_base)
+    Ok(sat_result(limit, false, met, steps_base))
 }
 
 /// Like `saturate`, but prints each match and union when `labels` is provided.
@@ -648,7 +668,7 @@ pub fn saturate_trace<Cfg, L, M, S, const T: bool, const P: bool>(
     model: &M,
     limit: usize,
     globals: &crate::resolve::GlobalCtx<S, Cfg::G>,
-) -> SatResult
+) -> Result<SatResult, EvalError>
 where
     Cfg: EGraphConfig,
     S: DenseId,
@@ -656,10 +676,11 @@ where
     M: LitModel<Value = L>,
     MSetCanon: VarCanon<Cfg::G, Cfg::C>,
 {
-    use crate::ematch::run_query;
-
     let steps_base = crate::ematch::match_steps();
     let mut total_iter = 0;
+    // `run_query_into` rather than `run_query`: the latter drops its pool, and
+    // with it the guard fault the matcher recorded there.
+    let mut pool = MatchPool::new();
     for i in 0..limit {
         total_iter = i + 1;
         eg.rebuild();
@@ -670,7 +691,11 @@ where
         for (label, rule) in rules {
             let plan = crate::schedule::schedule_with_stats(&rule.query, &stats);
             let shape = &plan.shape;
-            let matches = run_query(&plan, eg, &vindex, globals);
+            crate::ematch::run_query_into(&plan, eg, &vindex, globals, &mut pool);
+            if let Some(fault) = pool.guard_fault() {
+                return Err(crate::apply::name_fault(fault.clone(), rule, eg));
+            }
+            let matches: Vec<_> = (0..pool.len()).map(|j| pool.clone_match(j)).collect();
             for m in &matches {
                 // Print node bindings (skip internal ?-prefixed names)
                 let binds: Vec<String> = shape
@@ -679,7 +704,16 @@ where
                     .enumerate()
                     .filter(|(_, name)| !name.starts_with('?'))
                     .map(|(i, name)| {
-                        let vid = crate::ast::VarId::new(i as u16);
+                        // `shape.nodes` is the interner's own name table and its
+                        // positions ARE the `VarId`s: every entry was appended by
+                        // `VarScope::intern_var`, which mints through
+                        // `u16::try_from(self.nodes.len())` and refuses beyond it.
+                        // So `i < nodes.len() <= u16::MAX as usize + 1` and the
+                        // narrowing cannot fail; a failure would be that table
+                        // holding an id it could not have minted.
+                        let raw = u16::try_from(i)
+                            .expect("node var position: minted by a checked intern_var");
+                        let vid = crate::ast::VarId::new(raw);
                         format!("{name}=e{}", m.get(vid).to_usize())
                     })
                     .collect();
@@ -688,7 +722,11 @@ where
                     .iter()
                     .enumerate()
                     .map(|(i, name)| {
-                        let vid = crate::ast::LitValVarId::new(i as u16);
+                        // Same bound as `shape.nodes` above, from
+                        // `VarScope::intern_lit_val`'s checked mint.
+                        let raw = u16::try_from(i)
+                            .expect("lit var position: minted by a checked intern_lit_val");
+                        let vid = crate::ast::LitValVarId::new(raw);
                         let lid = m.get_lit_val(vid);
                         format!("{name}={}", eg.lits().get(lid))
                     })
@@ -696,17 +734,20 @@ where
                 let all_binds = [binds, lit_binds].concat().join(", ");
                 eprint!("  [{label}] match: {all_binds}");
 
-                changes += crate::apply::apply_rule_actions(rule, m, eg, model, globals);
+                // The newline first, so the trace line for the match that
+                // faulted is closed before the error propagates.
+                let applied = crate::apply::apply_rule_actions(rule, m, eg, model, globals);
                 eprintln!();
+                changes += applied.map_err(|e| crate::apply::name_fault(e, rule, eg))?;
             }
         }
         if changes == 0 {
             eprintln!("-- fixpoint after {total_iter} iterations --");
-            return sat_result(total_iter, true, false, steps_base);
+            return Ok(sat_result(total_iter, true, false, steps_base));
         }
         eprintln!("-- iteration {total_iter}: {changes} changes --");
     }
-    sat_result(total_iter, false, false, steps_base)
+    Ok(sat_result(total_iter, false, false, steps_base))
 }
 
 #[cfg(test)]
@@ -903,11 +944,13 @@ mod tests {
         let (mut a, rules_a, n) = setup();
         let ra = saturate::<DefaultConfig, _, _, _, false, false>(
             &rules_a, &mut a, &NiraModel, 30, &globals,
-        );
+        )
+        .unwrap();
         let (mut b, rules_b, n2) = setup();
         let rb = saturate_semi::<DefaultConfig, _, _, _, false, false>(
             &rules_b, &mut b, &NiraModel, 30, &globals,
-        );
+        )
+        .unwrap();
 
         // Same fixpoint.
         assert_eq!(n, n2);
@@ -993,12 +1036,14 @@ mod tests {
         let (mut a, rules_a, n) = setup();
         let ra = saturate::<DefaultConfig, _, _, _, false, false>(
             &rules_a, &mut a, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
 
         let (mut b, rules_b, n2) = setup();
         let rb = saturate_semi::<DefaultConfig, _, _, _, false, false>(
             &rules_b, &mut b, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
 
         assert_eq!(n, n2, "setup must be deterministic");
         assert_eq!(ra.saturated, rb.saturated, "saturation flag mismatch");
@@ -1181,11 +1226,11 @@ mod tests {
                 let (mut a, rules_a, n) = build(&specs, mask);
                 let ra = saturate::<DefaultConfig, _, _, _, false, false>(
                     &rules_a, &mut a, &NiraModel, 40, &globals,
-                );
+                ).unwrap();
                 let (mut b, rules_b, _n2) = build(&specs, mask);
                 let rb = saturate_semi::<DefaultConfig, _, _, _, false, false>(
                     &rules_b, &mut b, &NiraModel, 40, &globals,
-                );
+                ).unwrap();
 
                 prop_assert_eq!(ra.saturated, rb.saturated, "saturation flag");
                 prop_assert_eq!(
@@ -1277,11 +1322,13 @@ mod tests {
             let (mut a, rules_a, n) = build_nested(&specs, mask);
             let ra = saturate::<DefaultConfig, _, _, _, false, false>(
                 &rules_a, &mut a, &NiraModel, round_cap, &globals,
-            );
+            )
+            .unwrap();
             let (mut b, rules_b, _n2) = build_nested(&specs, mask);
             let rb = saturate_semi::<DefaultConfig, _, _, _, false, false>(
                 &rules_b, &mut b, &NiraModel, round_cap, &globals,
-            );
+            )
+            .unwrap();
 
             assert_eq!(n, 6, "fixture shape");
             assert!(
@@ -1324,11 +1371,11 @@ mod tests {
                 let (mut a, rules_a, n) = build_nested(&specs, mask);
                 let ra = saturate::<DefaultConfig, _, _, _, false, false>(
                     &rules_a, &mut a, &NiraModel, 12, &globals,
-                );
+                ).unwrap();
                 let (mut b, rules_b, _n2) = build_nested(&specs, mask);
                 let rb = saturate_semi::<DefaultConfig, _, _, _, false, false>(
                     &rules_b, &mut b, &NiraModel, 12, &globals,
-                );
+                ).unwrap();
 
                 prop_assert_eq!(ra.saturated, rb.saturated, "saturation flag");
                 prop_assert_eq!(
@@ -2139,11 +2186,13 @@ mod tests {
         let (mut a, rules_a, n) = setup();
         saturate::<DefaultConfig, _, _, _, false, false>(
             &rules_a, &mut a, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         let (mut b, rules_b, n2) = setup();
         saturate_semi::<DefaultConfig, _, _, _, false, false>(
             &rules_b, &mut b, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         assert_eq!(n, n2);
         assert_eq!(
             partition_over(&a, n),
@@ -2295,11 +2344,13 @@ mod tests {
         let (mut a, rules_a, n) = build();
         let ra = saturate::<DefaultConfig, _, _, _, false, true>(
             &rules_a, &mut a, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         let (mut b, rules_b, n2) = build();
         let rb = saturate_semi::<DefaultConfig, _, _, _, false, true>(
             &rules_b, &mut b, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         assert_eq!(n, n2);
         assert_eq!(
             ra.saturated, rb.saturated,
@@ -2372,7 +2423,8 @@ mod tests {
         let tok = eg.mark(crate::containers::ShrinkPolicy::Never);
         let _ = saturate_semi::<DefaultConfig, _, _, _, true, false>(
             &rules, &mut eg, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         eg.restore(tok);
         assert!(
             eg.touched().is_empty(),
@@ -2383,13 +2435,15 @@ mod tests {
         // naive run from the same input.
         let rs = saturate_semi::<DefaultConfig, _, _, _, true, false>(
             &rules, &mut eg, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         assert!(rs.saturated);
 
         let (mut egn, rules_n, n2) = build();
         let _ = saturate::<DefaultConfig, _, _, _, true, false>(
             &rules_n, &mut egn, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         assert_eq!(n, n2);
         assert_eq!(
             partition_over(&eg, n),
@@ -2415,7 +2469,8 @@ mod tests {
         let (mut eg, rules) = setup();
         let r1 = saturate_semi::<DefaultConfig, _, _, _, false, false>(
             &rules, &mut eg, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         assert!(
             r1.saturated,
             "should reach a fixpoint (final round empty-delta)"
@@ -2425,7 +2480,8 @@ mod tests {
         // re-finds the matches, every application is idempotent → 0 changes.
         let r2 = saturate_semi::<DefaultConfig, _, _, _, false, false>(
             &rules, &mut eg, &NiraModel, 50, &globals,
-        );
+        )
+        .unwrap();
         assert!(r2.saturated);
         assert_eq!(
             r2.iterations, 1,
@@ -2447,7 +2503,8 @@ mod tests {
             &NiraModel,
             10,
             &globals,
-        );
+        )
+        .unwrap();
         assert!(res.saturated);
         assert_eq!(res.iterations, 1);
     }
@@ -2467,7 +2524,8 @@ mod tests {
             &NiraModel,
             10,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
 
         assert!(res.saturated);
         let fba = eg.add(eg.ops().id_by_name("f").unwrap(), &[b, a]);
@@ -2488,7 +2546,8 @@ mod tests {
             &NiraModel,
             10,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
 
         assert!(res.saturated);
         assert_eq!(res.iterations, 1);
@@ -2528,7 +2587,8 @@ mod tests {
             &model,
             10,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
 
         assert!(res.saturated);
 
@@ -2556,7 +2616,8 @@ mod tests {
             &NiraModel,
             10,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
 
         assert!(res.saturated);
         // g(a) and g(b) should both be merged with f(a,b)
@@ -2619,7 +2680,8 @@ mod tests {
             &model,
             10,
             &globals,
-        );
+        )
+        .unwrap();
         assert!(res.saturated);
 
         let v9 = eg.intern_lit(NiraLitVal::Int(BigInt::from(9)));
@@ -2703,7 +2765,8 @@ mod tests {
             &model,
             20,
             &crate::resolve::GlobalCtx::<crate::id::SortId, crate::id::ENodeId>::new(),
-        );
+        )
+        .unwrap();
 
         eg.rebuild();
         eg.show("after_saturation");

--- a/egraph/src/sortcheck.rs
+++ b/egraph/src/sortcheck.rs
@@ -30,6 +30,24 @@ impl std::fmt::Display for SortError {
     }
 }
 
+impl SortError {
+    /// The message with a **line and column** instead of the byte offsets `Display` prints.
+    ///
+    /// `Display` cannot do this: it has no access to the source text, so it can only report
+    /// the offsets the parser recorded. A caller that still holds the source should prefer
+    /// this — `sort error at line 4 column 12:` is actionable where `sort error at 87..93:`
+    /// is not.
+    ///
+    /// Note this carries the `sort error` prefix itself, exactly as `Display` does, so a
+    /// caller prints it bare. Prefixing it again yields `sort error: sort error at ...`.
+    pub fn render(&self, src: &str) -> String {
+        match self.span.render_in(src) {
+            Some(at) => format!("sort error at {at}: {}", self.msg),
+            None => format!("sort error: {}", self.msg),
+        }
+    }
+}
+
 fn serr(msg: impl Into<String>, span: Span) -> SortError {
     SortError {
         msg: msg.into(),
@@ -71,12 +89,17 @@ pub enum CCommand<O, S, L> {
         root_vid: crate::ast::VarId,
         subsume: bool,
         ruleset: Option<crate::apply::RulesetId>,
+        /// Source span of the rule's left-hand side, carried so a runtime fault in this
+        /// rule can name a line rather than only the generated rule name.
+        span: Span,
     },
     Rule {
         query: ResolvedQuery<O, S, L>,
         rhs_locals: crate::resolve::RhsLocalShape,
         actions: Vec<crate::resolve::ResolvedAction<O, S, L>>,
         ruleset: Option<crate::apply::RulesetId>,
+        /// Source span of the rule's first body pattern; see `Rewrite::span`.
+        span: Span,
     },
     Run {
         ruleset: Option<crate::apply::RulesetId>,
@@ -864,6 +887,7 @@ where
                 root_vid,
                 subsume,
                 ruleset,
+                span: lhs_span,
             })
         }
         SurfaceCommand::Rule {
@@ -872,6 +896,7 @@ where
             ruleset,
         } => {
             let ruleset = rulesets.resolve(&ruleset)?;
+            let body_span = body.first().map_or(Span::Dummy, |p| p.span());
             let fq = flatten_surface(&body, eg.ops()).map_err(|e| serr(e, Span::Dummy))?;
             let rq = resolve(&fq, eg.ops(), eg.sorts(), model, globals)
                 .map_err(|e| serr(e.to_string(), Span::Dummy))?;
@@ -888,6 +913,7 @@ where
                 rhs_locals,
                 actions,
                 ruleset,
+                span: body_span,
             })
         }
     }

--- a/egraph/tests/au_proof_certificates.rs
+++ b/egraph/tests/au_proof_certificates.rs
@@ -645,7 +645,8 @@ fn certificate_trace_with_rewrite_step() {
     // and assert the axioms, then close congruence.
     let index = IndexStore::build(&eg);
     let stats = IndexStats::from_index(&index);
-    let fired = apply_rule(&rule, &mut eg, &index, &stats, &model, &globals);
+    let fired = apply_rule(&rule, &mut eg, &index, &stats, &model, &globals)
+        .expect("the rule's RHS applies no primitive");
     assert!(fired > 0, "rule (h1 x) -> (c) must fire on h1(a)");
     eg.merge_justified(h2b, d, Justification::Axiom { axiom_id: ax_h2 });
     eg.merge_justified(k1u, p, Justification::Axiom { axiom_id: ax_k1 });
@@ -688,7 +689,8 @@ fn certificate_trace_with_rewrite_step() {
 
     let index = IndexStore::build(&eg);
     let stats = IndexStats::from_index(&index);
-    let fired = apply_rule(&rule, &mut eg, &index, &stats, &model, &globals);
+    let fired = apply_rule(&rule, &mut eg, &index, &stats, &model, &globals)
+        .expect("the rule's RHS applies no primitive");
     assert!(fired > 0, "rule must fire again after restore");
     eg.merge_justified(h2b, d, Justification::Axiom { axiom_id: ax_h2 });
     eg.merge_justified(k1u, p, Justification::Axiom { axiom_id: ax_k1 });

--- a/egraph/tests/egg/ac_flatten_order_dependence.egg
+++ b/egraph/tests/egg/ac_flatten_order_dependence.egg
@@ -1,0 +1,40 @@
+;; EXPECT: error
+;; TYPES: machine
+;; ASSERTS AN INCOMPLETENESS, ON PURPOSE. The companion
+;; `ac_flatten_order_dependence_eager.egg` is the same program under `--derive-ac-eqs`,
+;; where it passes.
+;;
+;; AC flattening splices a nested same-op child only when the child's class is NOT `atomic`
+;; (`flatten_ac_children`, design §6c). `atomic` answers "is this class referenced as a
+;; non-same-op child" with *so far*, and it is monotone-true, so building `t0` first makes
+;; `[Mul(D,D)]` atomic and `t2` then stores the nested spelling. Reorder the two `let`s
+;; (`ac_flatten_order_dependence_reordered.egg`) and the same program proves the check.
+;;
+;; This is left as-is deliberately. Every way to remove the order dependence at build time
+;; is worse: splicing unconditionally destroys the §5b summand pair
+;; (`inverse_cancel_keeps_atomic_pair.egg`), never splicing regresses
+;; `ac_flatten_build.egg`, and deciding on the written syntax instead of the class still
+;; breaks §5b for a §5b term written inline. Note `atomic` *is* order-independent within a
+;; single term, since argument evaluation fixes the order — the dependence is only across
+;; statements, which is exactly the AC incompleteness the eager and lazy modes exist to
+;; close.
+;;
+;; Supplying the missing equality in plain mode instead was measured at +73% nodes on
+;; `rhs_mult_expr.egg` under `--derive-ac-eqs`, for a consequence plain mode is defined not
+;; to derive. If this fixture ever starts passing in plain mode, that budget is being spent
+;; somewhere: check what changed before relaxing the expectation.
+
+(sort E)
+(constructor A () E)
+(constructor D () E)
+(constructor Zero () E)
+(constructor One () E)
+(constructor Add (E) E :assoc :comm :identity (Zero))
+(constructor Mul (E) E :assoc :comm :identity (One))
+
+;; Makes `[Mul(D,D)]` atomic by referencing it as an `Add` child.
+(let t0 (Add (Mul (D) (D)) (A)))
+(let t1 (Mul (D) (D) (A) (D)))
+(let t2 (Mul (A) (D) (Mul (D) (D))))
+;; True in the AC theory; NOT derived by canonization plus congruence alone.
+(check (= t1 t2))

--- a/egraph/tests/egg/ac_flatten_order_dependence_eager.egg
+++ b/egraph/tests/egg/ac_flatten_order_dependence_eager.egg
@@ -1,0 +1,20 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; DERIVE_AC_EQS: on
+;; The eager companion of `ac_flatten_order_dependence.egg`: byte-identical program, with AC
+;; completion enabled. It passes, which is the whole argument for leaving plain mode alone —
+;; the equality `t1 = t2` is a genuine AC consequence, and deriving it is completion's job,
+;; under completion's growth budget.
+
+(sort E)
+(constructor A () E)
+(constructor D () E)
+(constructor Zero () E)
+(constructor One () E)
+(constructor Add (E) E :assoc :comm :identity (Zero))
+(constructor Mul (E) E :assoc :comm :identity (One))
+
+(let t0 (Add (Mul (D) (D)) (A)))
+(let t1 (Mul (D) (D) (A) (D)))
+(let t2 (Mul (A) (D) (Mul (D) (D))))
+(check (= t1 t2))

--- a/egraph/tests/egg/ac_flatten_order_dependence_reordered.egg
+++ b/egraph/tests/egg/ac_flatten_order_dependence_reordered.egg
@@ -1,0 +1,23 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; The other half of `ac_flatten_order_dependence.egg`: the SAME program with `t0` moved
+;; after `t2`. Now nothing has referenced `[Mul(D,D)]` as a non-same-op child when `t2` is
+;; built, so the class is not yet `atomic`, `flatten_ac_children` splices it, and `t2` is
+;; stored flat — equal to `t1` by canonization alone.
+;;
+;; The pair of fixtures is the point: plain mode's answer to `t1 = t2` depends on statement
+;; order. That is documented AC incompleteness, not a soundness bug — neither fixture ever
+;; asserts a false equality — and `--derive-ac-eqs` proves it in both orders.
+
+(sort E)
+(constructor A () E)
+(constructor D () E)
+(constructor Zero () E)
+(constructor One () E)
+(constructor Add (E) E :assoc :comm :identity (Zero))
+(constructor Mul (E) E :assoc :comm :identity (One))
+
+(let t1 (Mul (D) (D) (A) (D)))
+(let t2 (Mul (A) (D) (Mul (D) (D))))
+(let t0 (Add (Mul (D) (D)) (A)))
+(check (= t1 t2))

--- a/egraph/tests/egg/bignum_div_by_zero_error.egg
+++ b/egraph/tests/egg/bignum_div_by_zero_error.egg
@@ -1,0 +1,9 @@
+;; EXPECT: error
+;; TYPES: bignum
+;; Arbitrary precision removes overflow, not partiality: `IBig::/` still has no
+;; value at a zero divisor. Reported the same way as the machine-width case, so
+;; the type group does not change whether a program error is a panic.
+(datatype Math (Num IBig) (Div Math Math))
+(rewrite (Div (Num x) (Num y)) (Num (IBig::/ x y)))
+(let e (Div (Num 7) (Num 0)))
+(run 10)

--- a/egraph/tests/egg/checked_overflow.egg
+++ b/egraph/tests/egg/checked_overflow.egg
@@ -1,5 +1,8 @@
-;; EXPECT: panic
+;; EXPECT: error
 ;; TYPES: machine
+;; Checked arithmetic at the machine widths: `i64::+` has no i64 value here, so
+;; the run reports the operation and its operands and stops. It used to abort the
+;; process from inside the model's `expect`.
 (datatype Math (Num i64) (Add Math Math))
 (rewrite (Add (Num x) (Num y)) (Num (i64::+ x y)))
 (let e (Add (Num 9223372036854775807) (Num 1)))

--- a/egraph/tests/egg/div_by_zero_error.egg
+++ b/egraph/tests/egg/div_by_zero_error.egg
@@ -1,0 +1,11 @@
+;; EXPECT: error
+;; TYPES: machine
+;; A partial primitive on the right-hand side, reached with operands that put it
+;; outside its domain. The rule is well sorted and the match is real; only the
+;; divisor makes it undefined, and that is known no earlier than the firing. The
+;; run stops with a program error naming the rule, the operation, and the
+;; operands, instead of panicking inside `i64::checked_div`'s caller.
+(datatype Math (Num i64) (Div Math Math))
+(rewrite (Div (Num x) (Num y)) (Num (i64::/ x y)))
+(let e (Div (Num 7) (Num 0)))
+(run 10)

--- a/egraph/tests/egg/guard_div_by_zero_error.egg
+++ b/egraph/tests/egg/guard_div_by_zero_error.egg
@@ -1,0 +1,11 @@
+;; EXPECT: error
+;; TYPES: machine
+;; The same fault inside a `:when` guard rather than a right-hand side. A guard
+;; that has no value on an assignment is NOT read as a guard that failed: the
+;; matcher records the fault and the run ends. Treating it as false would hide a
+;; partial rule and make the result depend on which assignments the join
+;; happened to enumerate.
+(datatype Math (Num i64) (Mark Math))
+(rewrite (Num a) (Mark (Num a)) :when ((i64::< (i64::/ 100 a) 3)))
+(let z (Num 0))
+(run 10)

--- a/egraph/tests/egg/inverse_cancel_after_merge.egg
+++ b/egraph/tests/egg/inverse_cancel_after_merge.egg
@@ -1,0 +1,28 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; Inverse-pair cancellation is a canonization law that plain mode applies at build
+;; (`group_cancel_pairs` in `add`), but its condition *opens*: the pair `x, inv(x)` can be
+;; created by a merge long after the node was built. Nothing re-ran the law, so the law
+;; applied or not depending on statement order.
+;;
+;; Here `(Add A (Neg B))` is built while A and B are still distinct, so no pair is visible.
+;; `(union A B)` then makes `Neg A` and `Neg B` congruent, and the stored monomial becomes
+;; `+{A, Neg A}` — which is the unit. `canon_repair_round` re-applies cancellation after the
+;; merge. The control fixture writes the union first, which always worked.
+;;
+;; Cancellation is purely subtractive, so re-applying it cannot grow the graph and needs no
+;; completion budget: this holds in plain mode, with no rules and no run.
+
+(sort E)
+(constructor A () E)
+(constructor B () E)
+(constructor Zero () E)
+(constructor Neg (E) E)
+(constructor Add (E) E :assoc :comm :identity (Zero) :inverse Neg)
+
+(let s (Add (A) (Neg (B))))
+(union (A) (B))
+;; Congruence alone gives this one.
+(check (= (Neg (A)) (Neg (B))))
+;; This is the one the missing re-application lost.
+(check (= s (Zero)))

--- a/egraph/tests/egg/inverse_cancel_after_merge_control.egg
+++ b/egraph/tests/egg/inverse_cancel_after_merge_control.egg
@@ -1,0 +1,16 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; The control for `inverse_cancel_after_merge.egg`: union first, so the pair is already
+;; visible when `add` canonicalizes and build-time cancellation fires. This order always
+;; passed; it pins the other side of the equivalence.
+
+(sort E)
+(constructor A () E)
+(constructor B () E)
+(constructor Zero () E)
+(constructor Neg (E) E)
+(constructor Add (E) E :assoc :comm :identity (Zero) :inverse Neg)
+
+(union (A) (B))
+(let s (Add (A) (Neg (B))))
+(check (= s (Zero)))

--- a/egraph/tests/egg/inverse_cancel_keeps_atomic_pair.egg
+++ b/egraph/tests/egg/inverse_cancel_keeps_atomic_pair.egg
@@ -1,0 +1,23 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; Guard for design §5b against the flattening repair that was tried and rejected: the
+;; summand pair in `+(c, neg(c))`, where `c` is itself a sum, only cancels because `c` is
+;; kept as ONE summand. `c`'s class is `atomic` (it is referenced as `Neg`'s child), so
+;; `flatten_ac_children` declines to splice it and the pair stays visible.
+;;
+;; Splicing it — which is what "flatten whenever the class holds a same-op node" does —
+;; turns the node into `+{A, B, Neg c}`, no pair is adjacent, and `t = Zero` is lost. That
+;; is why the `atomic` condition is not a bookkeeping detail, and why the AC flattening
+;; order dependence is left to the eager/lazy modes instead of repaired in plain mode.
+
+(sort E)
+(constructor A () E)
+(constructor B () E)
+(constructor Zero () E)
+(constructor Neg (E) E)
+(constructor Add (E) E :assoc :comm :identity (Zero) :inverse Neg)
+
+(let c (Add (A) (B)))
+(let n (Neg c))
+(let t (Add c n))
+(check (= t (Zero)))

--- a/egraph/tests/egg/ok_eq_atom_one_side_bound.egg
+++ b/egraph/tests/egg/ok_eq_atom_one_side_bound.egg
@@ -1,0 +1,10 @@
+;; EXPECT: ok
+;; The control: with either side bound by another atom the eager fixpoint lowers the `Eq`
+;; as a `CopyBinding`, in either textual order.
+(sort E)
+(function h (E) E)
+(function p () E)
+(let z (h (p)))
+(rule ((h x) (= x y)) ((union x y)))
+(rule ((= u v) (h v)) ((union u v)))
+(run 1)

--- a/egraph/tests/egg/ok_rest_var_distinct_names.egg
+++ b/egraph/tests/egg/ok_rest_var_distinct_names.egg
@@ -1,0 +1,13 @@
+;; EXPECT: ok
+;; The control for the rest-linearity rejection: distinct rest names are the ordinary
+;; window pattern and must still compile and fire.
+(sort E)
+(function S (E) E :assoc)
+(function a () E)
+(function b () E)
+(function c () E)
+(function W () E)
+(let t (S (a) (b) (c)))
+(rule ((S ..p x ..q)) ((union (W) x)))
+(run 2)
+(check (= (W) (b)))

--- a/egraph/tests/egg/reject_eq_atom_neither_side_bound.egg
+++ b/egraph/tests/egg/reject_eq_atom_neither_side_bound.egg
@@ -1,0 +1,11 @@
+;; EXPECT: sort-error
+;; `(= x y)` with neither side bound elsewhere is lowered by neither scheduler phase:
+;; `try_eager_lower` returns None and phase B's argmin skips `Eq`. The atom was dropped,
+;; the two node variables stayed in the MatchShape, and `MatchPool::push` unwrapped an
+;; unset slot — a process abort. This is the local counterpart of what `Step::BindGlobal`
+;; already handles for a global.
+(sort E)
+(function h (E) E)
+(function p () E)
+(let z (h (p)))
+(rule ((= x y)) ((union x y)))

--- a/egraph/tests/egg/reject_eq_atom_unbound_with_other_atom.egg
+++ b/egraph/tests/egg/reject_eq_atom_unbound_with_other_atom.egg
@@ -1,0 +1,7 @@
+;; EXPECT: sort-error
+;; The dropped `Eq` need not be the only atom, and the RHS need not mention its variables.
+(sort E)
+(function h (E) E)
+(function p () E)
+(let z (h (p)))
+(rule ((h q) (= x y)) ((union q q)))

--- a/egraph/tests/egg/reject_rest_var_aliased_one_atom.egg
+++ b/egraph/tests/egg/reject_rest_var_aliased_one_atom.egg
@@ -1,0 +1,13 @@
+;; EXPECT: sort-error
+;; `pre` and `suf` of one variadic atom are two writers of the same span, so aliasing them
+;; is the same defect as sharing a rest between atoms. On (S (a) (b) (c)) the correct
+;; answer is no match ([] != [b c], [a] != [c], [a b] != []); with the constraint dropped
+;; `x` ranged over all three children.
+(sort E)
+(function S (E) E :assoc)
+(function a () E)
+(function b () E)
+(function c () E)
+(function W () E)
+(let t (S (a) (b) (c)))
+(rule ((S ..r x ..r)) ((union (W) x)))

--- a/egraph/tests/egg/reject_rest_var_shared_across_atoms.egg
+++ b/egraph/tests/egg/reject_rest_var_shared_across_atoms.egg
@@ -1,0 +1,15 @@
+;; EXPECT: sort-error
+;; A rest variable shared by two atoms has no lowering: both `ExpandA` steps write
+;; SeqVarId(0), the second overwrites the first, and the equality the repeated name asks
+;; for is never checked. On this graph atom 1 admits r=[a] and r=[c] while atom 2 admits
+;; r=[b] and r=[d], so there is no match — but with the constraint dropped the rule fired
+;; and derived (b) = (d).
+(sort E)
+(function S (E) E :assoc)
+(function a () E)
+(function b () E)
+(function c () E)
+(function d () E)
+(let t1 (S (a) (b)))
+(let t2 (S (c) (d)))
+(rule ((S ..r x) (S y ..r)) ((union x y)))

--- a/egraph/tests/egg/reject_rest_var_shared_mset.egg
+++ b/egraph/tests/egg/reject_rest_var_shared_mset.egg
@@ -1,0 +1,11 @@
+;; EXPECT: sort-error
+;; The AC rest (`DecomposeAC`, MsetVarId) has the same single-writer requirement.
+(sort E)
+(function M (E) E :assoc-comm)
+(function a () E)
+(function b () E)
+(function c () E)
+(function d () E)
+(let t1 (M (a) (b)))
+(let t2 (M (c) (d)))
+(rule ((M ..r x) (M y ..r)) ((union x y)))

--- a/egraph/tests/egg/reject_rest_var_shared_set.egg
+++ b/egraph/tests/egg/reject_rest_var_shared_set.egg
@@ -1,0 +1,11 @@
+;; EXPECT: sort-error
+;; The ACI rest (`DecomposeACI`, SetVarId) has the same single-writer requirement.
+(sort E)
+(function U (E) E :assoc-comm-idem)
+(function a () E)
+(function b () E)
+(function c () E)
+(function d () E)
+(let t1 (U (a) (b)))
+(let t2 (U (c) (d)))
+(rule ((U ..r x) (U y ..r)) ((union x y)))

--- a/egraph/tests/egg/seq_flatten_order_independent.egg
+++ b/egraph/tests/egg/seq_flatten_order_independent.egg
@@ -1,0 +1,26 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; A-only associativity is a property of the term as *written*, so a nested same-op
+;; argument flattens whatever else has been unioned into its class. This used to depend on
+;; statement order: `pure_seq_node` declines a class that is not a pure `op`-sequence, so
+;; the `(union n (Blob))` below made `[n]` impure and `(F (F A B) C)` was stored nested,
+;; never rejoining `(F A B C)` — while writing the union *after* the nested term flattened
+;; it and the check passed. Same program, two answers.
+;;
+;; The decision now happens in the term builder (`push_seq_args`), where a nested
+;; application is still syntax, so no class membership can reach it. This is NOT an
+;; A-theory consequence of the union: `F(F(A,B),C) = F(A,B,C)` is associativity alone.
+
+(sort E)
+(constructor F (E) E :assoc)
+(constructor A () E)
+(constructor B () E)
+(constructor C () E)
+(constructor Blob () E)
+
+(let n (F (A) (B)))
+;; The union comes FIRST, which is the order that used to fail.
+(union n (Blob))
+(check (= (F (F (A) (B)) (C)) (F (A) (B) (C))))
+;; ... and the nested spelling is still equal to the flat one through the union, too.
+(check (= (F (Blob) (C)) (F (Blob) (C))))

--- a/egraph/tests/egg/seq_flatten_order_independent_control.egg
+++ b/egraph/tests/egg/seq_flatten_order_independent_control.egg
@@ -1,0 +1,17 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; The control for `seq_flatten_order_independent.egg`: the same program with the union
+;; written AFTER the nested term. This order always passed, so it pins the other side of
+;; the equivalence — both orders must now agree.
+
+(sort E)
+(constructor F (E) E :assoc)
+(constructor A () E)
+(constructor B () E)
+(constructor C () E)
+(constructor Blob () E)
+
+(let n (F (A) (B)))
+(check (= (F (F (A) (B)) (C)) (F (A) (B) (C))))
+(union n (Blob))
+(check (= (F (F (A) (B)) (C)) (F (A) (B) (C))))

--- a/egraph/tests/egg/seq_flatten_rhs_nesting.egg
+++ b/egraph/tests/egg/seq_flatten_rhs_nesting.egg
@@ -1,0 +1,39 @@
+;; EXPECT: ok
+;; TYPES: machine
+;; A rule's right-hand side is a syntax tree too, so a nested same-op application written in
+;; an RHS needs the same associativity flattening as one written in a ground term
+;; (`eval_seq_args` in `apply.rs`, the counterpart of `push_seq_args` in `interpret.rs`).
+;;
+;; The union below is what gives this fixture teeth. With `[F a b]` still pure, the
+;; class-level test in `flatten_seq_children` splices the nested child on its own and the RHS
+;; handling only saves an intermediate node. Unioning `Blob` into that class makes it impure,
+;; `pure_seq_node` declines it, and then flattening the RHS nesting is the *only* thing that
+;; puts `F(F(a,b),c)` and `F(a,b,c)` in one class — which is what associativity says, with no
+;; appeal to the union at all.
+
+(sort E)
+(constructor F (E) E :assoc)
+(constructor a () E)
+(constructor b () E)
+(constructor c () E)
+(constructor Blob () E)
+(constructor Seed () E)
+(constructor Flat () E)
+
+;; Make the inner sequence's class impure, so the class-level test declines it.
+(let inner (F (a) (b)))
+(union inner (Blob))
+
+;; The RHS writes the nesting explicitly; the other writes it flat.
+(rewrite (Seed) (F (F (a) (b)) (c)))
+(rewrite (Flat) (F (a) (b) (c)))
+
+(let s (Seed))
+(let f (Flat))
+(run 5)
+
+;; Both right-hand sides denote the same sequence, so both roots land in one class.
+(check (= s f))
+(check (= s (F (a) (b) (c))))
+;; Order is still not touched: flattening re-associates, it does not reorder.
+(check (!= s (F (c) (b) (a))))

--- a/egraph/tests/egg/ubig_sub_negative_error.egg
+++ b/egraph/tests/egg/ubig_sub_negative_error.egg
@@ -1,0 +1,10 @@
+;; EXPECT: error
+;; TYPES: bignum
+;; `UBig::-` is partial for a different reason than division: the operation is
+;; total on the integers but its result sort has no negatives, so `1 - 2` is
+;; outside the domain. `num_bigint::BigUint`'s own `-` panics there; the model
+;; checks the order first and reports instead.
+(datatype U (Sub UBig UBig) (UR UBig))
+(rewrite (Sub x y) (UR (UBig::- x y)))
+(let e (Sub 1 2))
+(run 10)

--- a/egraph/tests/egg_tests.rs
+++ b/egraph/tests/egg_tests.rs
@@ -384,6 +384,22 @@ egg_test!(
     "seq_flatten_order_independent_control.egg"
 );
 egg_test!(seq_flatten_rhs_nesting, "seq_flatten_rhs_nesting.egg");
+// Asserts a *documented incompleteness*, on purpose: plain mode declines the AC flatten
+// consequence in one statement order and derives it in the other, and `--derive-ac-eqs`
+// derives it in both. `ac-congruence-completeness.md` §6c records why every build-time
+// alternative is worse. If the plain-mode fixture starts passing, find out what changed.
+egg_test!(
+    ac_flatten_order_dependence,
+    "ac_flatten_order_dependence.egg"
+);
+egg_test!(
+    ac_flatten_order_dependence_reordered,
+    "ac_flatten_order_dependence_reordered.egg"
+);
+egg_test!(
+    ac_flatten_order_dependence_eager,
+    "ac_flatten_order_dependence_eager.egg"
+);
 egg_test!(a_interreduction_gap, "a_interreduction_gap.egg");
 egg_test!(a_interreduction_eager, "a_interreduction_eager.egg");
 egg_test!(a_interreduction_lazy, "a_interreduction_lazy.egg");

--- a/egraph/tests/egg_tests.rs
+++ b/egraph/tests/egg_tests.rs
@@ -373,6 +373,17 @@ egg_test!(
     inverse_cancel_keeps_atomic_pair,
     "inverse_cancel_keeps_atomic_pair.egg"
 );
+// A-only associativity on a written nested application, in both statement orders and on a
+// rule right-hand side.
+egg_test!(
+    seq_flatten_order_independent,
+    "seq_flatten_order_independent.egg"
+);
+egg_test!(
+    seq_flatten_order_independent_control,
+    "seq_flatten_order_independent_control.egg"
+);
+egg_test!(seq_flatten_rhs_nesting, "seq_flatten_rhs_nesting.egg");
 egg_test!(a_interreduction_gap, "a_interreduction_gap.egg");
 egg_test!(a_interreduction_eager, "a_interreduction_eager.egg");
 egg_test!(a_interreduction_lazy, "a_interreduction_lazy.egg");

--- a/egraph/tests/egg_tests.rs
+++ b/egraph/tests/egg_tests.rs
@@ -362,6 +362,17 @@ egg_test!(
     rhs_comprehension_filter_reject_node,
     "rhs_comprehension_filter_reject_node.egg"
 );
+// Inverse-pair cancellation re-applied after a merge creates the pair, in both statement
+// orders, plus the guard that the neighbouring `atomic` condition still keeps the §5b pair.
+egg_test!(inverse_cancel_after_merge, "inverse_cancel_after_merge.egg");
+egg_test!(
+    inverse_cancel_after_merge_control,
+    "inverse_cancel_after_merge_control.egg"
+);
+egg_test!(
+    inverse_cancel_keeps_atomic_pair,
+    "inverse_cancel_keeps_atomic_pair.egg"
+);
 egg_test!(a_interreduction_gap, "a_interreduction_gap.egg");
 egg_test!(a_interreduction_eager, "a_interreduction_eager.egg");
 egg_test!(a_interreduction_lazy, "a_interreduction_lazy.egg");

--- a/egraph/tests/egg_tests.rs
+++ b/egraph/tests/egg_tests.rs
@@ -5,7 +5,9 @@
 //! Each `.egg` file in `tests/egg/` is run through the interpreter. The first six lines may
 //! carry directive comments. The feature directives mirror the CLI flags, so a test file is
 //! self-contained, no env var needed:
-//!   ;; EXPECT: ok|check-failed|parse-error|sort-error|error|panic   outcome (default: ok)
+//!   ;; EXPECT: ok|check-failed|parse-error|sort-error|error   outcome (default: ok)
+//! No fixture expects a panic: an outcome a program can provoke is reported through
+//! `error`, and a panic is an engine bug, which is not something to pin with a test.
 //!   ;; TYPES: machine                                     type group (default: bignum)
 //!   ;; EVAL: naive|semi|both                              eval algorithm (default: both)
 //!   ;; DERIVE_AC_EQS: on                                  eager AC completion (default off)
@@ -215,53 +217,11 @@ fn check(path: &str) {
     semi_persistent_egraph::ematch::set_runtime_scheduling(false);
 }
 
-fn check_panic(path: &str) {
-    let src = std::fs::read_to_string(path).unwrap();
-    let directives = parse_directives(&src);
-    for strategy in directives.evals.iter().copied() {
-        let src = src.clone();
-        let cc = directives.derive_ac_eqs;
-        let basis_checks = directives.check_ac_basis;
-        let result = std::panic::catch_unwind(move || {
-            let surface_cmds = semi_persistent_egraph::parser::parse_program_v2(&src).unwrap();
-            let mut interp = Interpreter::<
-                semi_persistent_egraph::nodes::DefaultConfig,
-                MachineLit,
-                MachineModel,
-                true,
-                false,
-            >::new(MachineModel);
-            interp.set_strategy(strategy);
-            interp.set_cc(cc);
-            interp.set_basis_checks(basis_checks);
-            let mut globals = semi_persistent_egraph::resolve::GlobalCtx::new();
-            let checked = semi_persistent_egraph::sortcheck::sortcheck_program(
-                surface_cmds,
-                &mut interp.eg,
-                &interp.model,
-                &mut globals,
-            )
-            .unwrap();
-            let _ = interp.run_checked(&checked);
-        });
-        assert!(
-            result.is_err(),
-            "{path} [{strategy:?}]: expected panic but succeeded"
-        );
-    }
-}
-
 macro_rules! egg_test {
     ($name:ident, $file:expr) => {
         #[test]
         fn $name() {
             check(concat!("tests/egg/", $file));
-        }
-    };
-    ($name:ident, $file:expr, panic) => {
-        #[test]
-        fn $name() {
-            check_panic(concat!("tests/egg/", $file));
         }
     };
     // Unsupported-behavior fixture: runs only under `--ignored`; `$why` states the limitation.
@@ -276,7 +236,14 @@ macro_rules! egg_test {
 
 // ── Arithmetic: checked (default) ──
 egg_test!(checked_add_ok, "checked_add_ok.egg");
-egg_test!(checked_overflow, "checked_overflow.egg", panic);
+// A partial primitive applied outside its domain is a reported program error,
+// not a panic: the engine cannot pick a value, but the caller has to be able to
+// tell a bad program from an engine bug.
+egg_test!(checked_overflow, "checked_overflow.egg");
+egg_test!(div_by_zero_error, "div_by_zero_error.egg");
+egg_test!(bignum_div_by_zero_error, "bignum_div_by_zero_error.egg");
+egg_test!(ubig_sub_negative_error, "ubig_sub_negative_error.egg");
+egg_test!(guard_div_by_zero_error, "guard_div_by_zero_error.egg");
 
 // ── Arithmetic: wrapping ──
 egg_test!(wrapping_add, "wrapping_add.egg");

--- a/egraph/tests/egg_tests.rs
+++ b/egraph/tests/egg_tests.rs
@@ -632,6 +632,35 @@ egg_test!(
 
 egg_test!(eq_global_only_atom, "eq_global_only_atom.egg");
 
+// Whole-query resolve checks (`check_rest_vars_linear`, `check_nodes_bindable`). Both
+// reject query shapes the matcher cannot execute, and both shapes previously reached the
+// interpreter: the rest-variable one silently dropped the constraint and derived a false
+// equality, the `Eq` one aborted the process in `MatchPool::push`. Each rejection carries
+// its control, a query of the same shape that must still compile.
+egg_test!(
+    reject_rest_var_shared_across_atoms,
+    "reject_rest_var_shared_across_atoms.egg"
+);
+egg_test!(
+    reject_rest_var_aliased_one_atom,
+    "reject_rest_var_aliased_one_atom.egg"
+);
+egg_test!(
+    reject_rest_var_shared_mset,
+    "reject_rest_var_shared_mset.egg"
+);
+egg_test!(reject_rest_var_shared_set, "reject_rest_var_shared_set.egg");
+egg_test!(ok_rest_var_distinct_names, "ok_rest_var_distinct_names.egg");
+egg_test!(
+    reject_eq_atom_neither_side_bound,
+    "reject_eq_atom_neither_side_bound.egg"
+);
+egg_test!(
+    reject_eq_atom_unbound_with_other_atom,
+    "reject_eq_atom_unbound_with_other_atom.egg"
+);
+egg_test!(ok_eq_atom_one_side_bound, "ok_eq_atom_one_side_bound.egg");
+
 // The README's autoformalization example is executable documentation. Its
 // `checkau` commands guard the documented size-42 bound before domain
 // saturation, the size-8/9 identity-padding examples, and the size-35


### PR DESCRIPTION
Rest variables must now be linear, one writer per name; two writers silently overwrote each other, so the rule fired on assignments where the spans differ.

```lisp
(rule ((S ..r x ..r))       ((union (W) x)))   ; rejected
(rule ((S ..r x) (S y ..r)) ((union x y)))     ; rejected
(rule ((M x ..r) (M y ..r)) ((union x y)))     ; rejected, AC too
(rule ((S ..p x ..q))       ((union (W) x)))   ; accepted
```

An equality atom must bind at least one side; it panicked in `ematch` before.

```lisp
(rule ((= x y))        ((union x y)))   ; rejected
(rule ((h x) (= x y))  ((union x y)))   ; accepted
```

A partial primitive reports and exits nonzero instead of aborting inside the model's `expect`: division by zero, checked overflow, negative `UBig` subtraction, too-wide multiplicity.

`LitOpDesc::eval` returns `Option<V>`; a guard fault is recorded on the `MatchPool` and checked before any action runs, since the matcher has no `Result` to return.

Inverse-pair cancellation is re-applied after a merge creates the pair, so `(let s (Add A (Neg B)))` then `(union A B)` reduces to zero, as the reverse order already did.

A written nested `:assoc` application flattens from the syntax, in the term builder and in the rule right-hand side.

`pure_seq_node` reads the child's class and that test closes; `EGraph::add` cannot replace it, because there a nested application is indistinguishable from a class id that happens to be a `Seq` node.

`a_flatten_build.egg` drops from 15 nodes to 11.

The AC flattening order dependence is now documented, and three defects in `ac-congruence-completeness.md` were corrected:
- §5b contradicted §6c, 
- `WF_flat` as stated was false of the implementation,
- §6c's lemma establishes only that re-running the predicate changes nothing.

Four alternatives were rejected: 
- splicing unconditionally destroys the §5b cancellation pair and diverges in the completion normalizer,
- class purity still breaks §5b, 
- never splicing regresses `ac_flatten_build.egg`, 
- a post-merge repair costs 73% more nodes on `rhs_mult_expr.egg` under `--derive-ac-eqs`.

Diagnostics carry a line and column instead of byte offsets, and `main` no longer prefixes `sort error` onto a message whose `Display` already carries it.

`--push-pop clone` is rejected by the parser instead of parsing and then exiting 1 from `main`.

1792 tests pass, and a sweep over every fixture in five modes (895 cases) changes one node count, `a_flatten_build.egg` from 15 to 11, with every outcome class unchanged.